### PR TITLE
Show percentage of selections per option during submission

### DIFF
--- a/app/models/sheet.server.ts
+++ b/app/models/sheet.server.ts
@@ -113,6 +113,22 @@ export const readSheetLeaders = async (
   `;
 };
 
+export const readOptionSelectionCounts = async (
+  sheetId: string
+): Promise<Record<string, number>> => {
+  const counts = await db.propositionSelection.groupBy({
+    by: ["optionId"],
+    _count: { _all: true },
+    where: {
+      submission: { sheetId },
+    },
+  });
+
+  return Object.fromEntries(
+    counts.map(({ optionId, _count }) => [optionId, _count._all])
+  );
+};
+
 export const readSheetSummary = async (
   id: string
 ): Promise<{ totalPropositions: number; answeredPropositions: number }> => {

--- a/app/routes/sheets.$sheetId.submissions.new/components/PropositionCard/PropositionCardOption.tsx
+++ b/app/routes/sheets.$sheetId.submissions.new/components/PropositionCard/PropositionCardOption.tsx
@@ -4,10 +4,12 @@ export default function PropositionCardOption({
   option,
   index,
   onChange,
+  percentage,
 }: {
   option: any;
   index: number;
   onChange: ChangeEventHandler<HTMLInputElement>;
+  percentage: number | null;
 }) {
   return (
     <div className="w-full">
@@ -20,7 +22,7 @@ export default function PropositionCardOption({
         onChange={onChange}
       />
       <label
-        className="btn btn-outline w-full h-24 normal-case text-base font-semibold
+        className="btn btn-outline w-full h-24 flex-col gap-1 normal-case text-base font-semibold
              peer-checked:btn-primary peer-checked:font-bold peer-checked:text-lg
              transition-all hover:scale-[1.02] peer-checked:scale-[1.03]"
         htmlFor={option?.id}
@@ -31,6 +33,11 @@ export default function PropositionCardOption({
             ✓
           </span>
         </span>
+        {percentage !== null && (
+          <span className="text-xs font-normal opacity-50">
+            {percentage}% picked this
+          </span>
+        )}
       </label>
     </div>
   );

--- a/app/routes/sheets.$sheetId.submissions.new/components/PropositionCard/index.tsx
+++ b/app/routes/sheets.$sheetId.submissions.new/components/PropositionCard/index.tsx
@@ -9,8 +9,13 @@ const PropositionCard = forwardRef<
     proposition: Proposition & { options: PropositionOption[] };
     onSelection: Function;
     propositionIndex: number;
+    optionCounts: Record<string, number>;
   }
->(({ proposition, onSelection, propositionIndex }, ref) => {
+>(({ proposition, onSelection, propositionIndex, optionCounts }, ref) => {
+  const totalPicks = proposition.options.reduce(
+    (sum, opt) => sum + (optionCounts[opt.id] ?? 0),
+    0
+  );
   return (
     <div
       id={proposition.id}
@@ -53,6 +58,13 @@ const PropositionCard = forwardRef<
                   option={option}
                   onChange={() => onSelection(proposition?.id, option?.id)}
                   index={propositionIndex}
+                  percentage={
+                    totalPicks > 0
+                      ? Math.round(
+                          ((optionCounts[option.id] ?? 0) / totalPicks) * 100
+                        )
+                      : null
+                  }
                 />
               </div>
             ))}

--- a/app/routes/sheets.$sheetId.submissions.new/route.tsx
+++ b/app/routes/sheets.$sheetId.submissions.new/route.tsx
@@ -6,7 +6,7 @@ import {
 } from "@remix-run/node";
 import { Form, useLoaderData, useNavigation } from "@remix-run/react";
 import invariant from "tiny-invariant";
-import { readSheet } from "~/models/sheet.server";
+import { readSheet, readOptionSelectionCounts } from "~/models/sheet.server";
 import { createSubmission } from "~/models/submission.server";
 import { authenticator } from "~/services/auth.server";
 import PropositionCard from "./components/PropositionCard";
@@ -44,7 +44,9 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 
   if (sheet.status === "CLOSED") return redirect(`/sheets/${sheetId}`);
 
-  return json({ sheet, sailor });
+  const optionCounts = await readOptionSelectionCounts(sheetId);
+
+  return json({ sheet, sailor, optionCounts });
 };
 
 export const action = async ({ params, request }: ActionFunctionArgs) => {
@@ -68,7 +70,7 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
 };
 
 export default function Sheet() {
-  const { sheet, sailor } = useLoaderData<typeof loader>();
+  const { sheet, sailor, optionCounts } = useLoaderData<typeof loader>();
   const [selections, setSelections] = useState<object>({});
   const [hasStarted, setHasStarted] = useState(false);
   const [tiebreakerTouched, setTiebreakerTouched] = useState(false);
@@ -136,6 +138,7 @@ export default function Sheet() {
               ref={(el) => (propositionRefs.current[index] = el)}
               propositionIndex={index}
               proposition={proposition}
+              optionCounts={optionCounts}
               onSelection={(propositionId: string, optionId: string) => {
                 setSelections((prev) => {
                   const updated = {


### PR DESCRIPTION
## Summary
Users can now see the percentage breakdown of how many other submitters chose each proposition option while filling out their picks. This helps provide context and visibility into the crowd's selections.

## Details
- Added `readOptionSelectionCounts()` query to fetch selection counts per option for a sheet
- Percentages are calculated dynamically from existing submissions and update as new picks arrive
- Percentages only display when at least one submission exists; otherwise hidden
- UI remains readable on mobile with vertical stacking using flexbox

## Test plan
1. Create a sheet with multiple propositions and have multiple users submit picks
2. Visit the submission form and verify percentages display below each option
3. Confirm percentages sum to 100% per proposition
4. Verify percentages update when new submissions are added (reload the form)

🤖 Generated with [Claude Code](https://claude.com/claude-code)