### PR TITLE
Fix profile picture rotation with EXIF orientation

### DIFF
--- a/app/utils/image.server.ts
+++ b/app/utils/image.server.ts
@@ -7,6 +7,7 @@ import sharp from "sharp";
  */
 export async function compressProfilePicture(buffer: Buffer): Promise<Buffer> {
   return await sharp(buffer)
+    .rotate()
     .resize(500, 500, {
       fit: "cover",
       position: "center",


### PR DESCRIPTION
Auto-apply EXIF orientation when processing profile pictures.

Sharp's `.rotate()` method reads the EXIF Orientation tag and applies the correct transformation, then strips the tag from the output. Images now display correctly regardless of capture orientation.

**Acceptance criteria met:**
- Images respect EXIF orientation
- Correct orientation across browsers and devices
- Fix applies to newly uploaded images