### PR TITLE
Send SMS confirmation when a user submits picks

### DIFF
--- a/app/services/sms.server.ts
+++ b/app/services/sms.server.ts
@@ -1,6 +1,8 @@
 import { sendSMS as sendTwilioSMS } from "./twilio.server";
 import { createSMS } from "~/models/sms.server";
 
+const isProduction = process.env.NODE_ENV === "production";
+
 type SendSMSOptions = {
   phone: string;
   magicLink: string;
@@ -9,10 +11,46 @@ type SendSMSOptions = {
 export let sendSMS = async (options: SendSMSOptions) => {
   let body = options.magicLink;
   try {
-    const response = await sendTwilioSMS(options.phone, body);
-    await createSMS({ to: options.phone, body, response }); // keep a record in the db
+    if (isProduction) {
+      const response = await sendTwilioSMS(options.phone, body);
+      await createSMS({ to: options.phone, body, response });
+    } else {
+      console.log(`[DummySMS] To: ${options.phone}, Body: ${body}`);
+      await createSMS({
+        to: options.phone,
+        body,
+        response: { message: "Dummy SMS (dev mode)" },
+      });
+    }
   } catch (e) {
     console.error("Couldn't send: ", e);
     throw new Error("SMS Could not be sent.");
+  }
+};
+
+type SendConfirmationSMSOptions = {
+  phone: string;
+  sheetName: string;
+};
+
+export let sendSubmissionConfirmationSMS = async (
+  options: SendConfirmationSMSOptions,
+) => {
+  const body = `Ahoy! Your picks for "${options.sheetName}" have been received. Good luck, matey!\n\nFollow along live at https://betpirate.ca`;
+  try {
+    if (isProduction) {
+      const response = await sendTwilioSMS(options.phone, body);
+      await createSMS({ to: options.phone, body, response });
+    } else {
+      console.log(`[DummySMS] To: ${options.phone}, Body: ${body}`);
+      await createSMS({
+        to: options.phone,
+        body,
+        response: { message: "Dummy SMS (dev mode)" },
+      });
+    }
+  } catch (e) {
+    // Log the error but don't throw - SMS failure should not block submission
+    console.error("Couldn't send confirmation SMS: ", e);
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "santiago",
+  "name": "addis-ababa",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Sends a confirmation SMS to users after they successfully submit their picks
- Message includes a link to betpirate.ca for easy access to follow along live
- SMS failures are logged but don't block the submission flow
- Uses dummy SMS service in development to save Twilio credits

## Test plan
- [ ] Submit picks locally and verify `[DummySMS]` appears in console logs
- [ ] Verify SMS record is created in database with dummy response
- [ ] Deploy to production and verify real SMS is received after submitting picks

Closes BET-5

🤖 Generated with [Claude Code](https://claude.ai/code)