### PR TITLE
Support multi-option propositions in admin

### DIFF
--- a/app/models/proposition.server.ts
+++ b/app/models/proposition.server.ts
@@ -4,6 +4,7 @@ type PropositionOption = {
   title: string;
   shortTitle?: string;
   imageUrl?: string | null;
+  order?: number;
 };
 
 type Proposition = {
@@ -93,6 +94,31 @@ export const createPropositionOption = (
     data: {
       propositionId,
       ...data,
+    },
+  });
+};
+
+export const deletePropositionOptions = (ids: string[]) => {
+  if (ids.length === 0) return;
+  return db.propositionOption.deleteMany({
+    where: {
+      id: {
+        in: ids,
+      },
+    },
+  });
+};
+
+export const readPropositionOptionIds = (propositionId: string) => {
+  return db.proposition.findUnique({
+    where: { id: propositionId },
+    select: {
+      answerId: true,
+      options: {
+        select: {
+          id: true,
+        },
+      },
     },
   });
 };

--- a/app/models/sheet.server.ts
+++ b/app/models/sheet.server.ts
@@ -56,7 +56,9 @@ export const readSheet = (id: string) => {
           order: "asc",
         },
         include: {
-          options: true,
+          options: {
+            orderBy: [{ order: "asc" }, { id: "asc" }],
+          },
         },
       },
     },
@@ -86,7 +88,9 @@ export const readSheetWithSubmissions = (id: string) => {
       },
       propositions: {
         include: {
-          options: true,
+          options: {
+            orderBy: [{ order: "asc" }, { id: "asc" }],
+          },
         },
       },
     },

--- a/app/routes/sheets.$sheetId.propositions.tsx
+++ b/app/routes/sheets.$sheetId.propositions.tsx
@@ -38,8 +38,9 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
     order: nextOrder,
     imageUrl: imageUrl?.trim() ? imageUrl.trim() : null,
     ...propositionValue,
-    options: options.map((option) => ({
+    options: options.map((option, index) => ({
       ...option,
+      order: index + 1,
       imageUrl: option.imageUrl?.trim() ? option.imageUrl.trim() : null,
     })),
   });

--- a/prisma/migrations/20260204131500_add_proposition_option_order/migration.sql
+++ b/prisma/migrations/20260204131500_add_proposition_option_order/migration.sql
@@ -1,0 +1,13 @@
+-- Add ordering support for proposition options
+ALTER TABLE "PropositionOption" ADD COLUMN "order" INTEGER;
+
+WITH ordered AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (PARTITION BY "propositionId" ORDER BY id) AS row_num
+  FROM "PropositionOption"
+)
+UPDATE "PropositionOption" po
+SET "order" = ordered.row_num
+FROM ordered
+WHERE po.id = ordered.id;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model PropositionOption {
   title      String
   shortTitle String?
   imageUrl   String?
+  order      Int?
 
   proposition   Proposition @relation(name: "options", fields: [propositionId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   propositionId String

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -14,7 +14,10 @@ const defaultSheet = {
         shortTitle: "Coin toss",
         order: 1,
         options: {
-          create: [{ title: "Heads" }, { title: "Tails" }],
+          create: [
+            { title: "Heads", order: 1 },
+            { title: "Tails", order: 2 },
+          ],
         },
       },
       {
@@ -22,7 +25,10 @@ const defaultSheet = {
         shortTitle: "First score",
         order: 2,
         options: {
-          create: [{ title: "Home" }, { title: "Away" }],
+          create: [
+            { title: "Home", order: 1 },
+            { title: "Away", order: 2 },
+          ],
         },
       },
       {
@@ -30,7 +36,11 @@ const defaultSheet = {
         shortTitle: "Halftime",
         order: 3,
         options: {
-          create: [{ title: "Home" }, { title: "Away" }, { title: "Tie" }],
+          create: [
+            { title: "Home", order: 1 },
+            { title: "Away", order: 2 },
+            { title: "Tie", order: 3 },
+          ],
         },
       },
       {
@@ -38,7 +48,10 @@ const defaultSheet = {
         shortTitle: "Overtime",
         order: 4,
         options: {
-          create: [{ title: "Yes" }, { title: "No" }],
+          create: [
+            { title: "Yes", order: 1 },
+            { title: "No", order: 2 },
+          ],
         },
       },
     ],


### PR DESCRIPTION
Adds UI controls to add, remove, and reorder proposition options in the sheet admin. Persists option ordering on create/update and removes deleted options safely. Includes a migration and seed updates for option ordering.