### PR TITLE
BET-22: Sheet admin proposition card enhancements

### DIFF
--- a/app/routes/sheets.$sheetId.admin/route.tsx
+++ b/app/routes/sheets.$sheetId.admin/route.tsx
@@ -46,7 +46,7 @@ export default function SheetEdit() {
           </div>
         </div>
 
-        <SheetSchedule sheet={sheet} />
+        {sheet.status === "DRAFT" && <SheetSchedule sheet={sheet} />}
 
         {sheet.status === "DRAFT" && <EditSheet sheet={sheet} />}
         {sheet.status === "CLOSED" && <MarkSheet sheet={sheet} />}


### PR DESCRIPTION
## Summary

- Proposition cards now start collapsed, showing a thumbnail and title at a glance, with an Edit button to expand
- Reordering works while collapsed; the Collapse button becomes Save & Collapse when the form is dirty
- Save button is full-width with loading/success/error states and a status badge in the header
- Validation errors from the server are surfaced in an alert with the full error detail
- Closing time editor is hidden when the sheet is not in DRAFT status

🤖 Generated with [Claude Code](https://claude.com/claude-code)