### PR TITLE
Implement server-side pagination and search for admin submissions

### DIFF
--- a/app/routes/sheets.$sheetId.admin/components/Submissions/__tests__/index.test.tsx
+++ b/app/routes/sheets.$sheetId.admin/components/Submissions/__tests__/index.test.tsx
@@ -1,0 +1,316 @@
+/** @jest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import Submissions from "../index";
+
+// Mock Remix hooks
+jest.mock("@remix-run/react", () => ({
+  Form: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<{ method?: string; className?: string }>) => (
+    <form {...props}>{children}</form>
+  ),
+  useNavigation: () => ({ state: "idle", location: undefined }),
+  useSearchParams: () => [new URLSearchParams(), jest.fn()],
+}));
+
+// Mock the SubmissionRow component
+jest.mock("../SubmissionRow", () => {
+  return function MockSubmissionRow({
+    submission,
+  }: {
+    submission: { id: string; sailor: { username: string } };
+  }) {
+    return (
+      <tr data-testid={`row-${submission.id}`}>
+        <td>{submission.sailor.username}</td>
+      </tr>
+    );
+  };
+});
+
+const createSubmission = (
+  id: string,
+  overrides: Partial<{
+    isPaid: boolean;
+    username: string;
+    firstName: string;
+    lastName: string;
+    phone: string;
+  }> = {}
+) => ({
+  id,
+  isPaid: overrides.isPaid ?? false,
+  createdAt: "2024-01-15T10:30:00Z",
+  sheetId: "sheet-1",
+  sailor: {
+    username: overrides.username ?? `user${id}`,
+    firstName: overrides.firstName ?? `First${id}`,
+    lastName: overrides.lastName ?? `Last${id}`,
+    phone: overrides.phone ?? `+1555000${id.padStart(4, "0")}`,
+  },
+});
+
+const createPagination = (
+  overrides: Partial<{
+    page: number;
+    pageSize: number;
+    total: number;
+    paidCount: number;
+    totalPages: number;
+    search: string;
+  }> = {}
+) => ({
+  page: overrides.page ?? 1,
+  pageSize: overrides.pageSize ?? 25,
+  total: overrides.total ?? 0,
+  paidCount: overrides.paidCount ?? 0,
+  totalPages: overrides.totalPages ?? 1,
+  search: overrides.search ?? "",
+});
+
+const renderWithRouter = (ui: React.ReactElement) => {
+  return render(<BrowserRouter>{ui}</BrowserRouter>);
+};
+
+describe("Submissions", () => {
+  describe("stats display", () => {
+    it("shows total submissions count", () => {
+      const submissions = [createSubmission("1"), createSubmission("2")];
+      const pagination = createPagination({ total: 2 });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      expect(screen.getByText("Total Submissions")).toBeInTheDocument();
+      const totalLabel = screen.getByText("Total Submissions");
+      const totalStat = totalLabel.closest(".stat");
+      expect(totalStat?.querySelector(".stat-value")).toHaveTextContent("2");
+    });
+
+    it("shows paid/unpaid breakdown", () => {
+      const submissions = [
+        createSubmission("1", { isPaid: true }),
+        createSubmission("2", { isPaid: true }),
+        createSubmission("3", { isPaid: false }),
+      ];
+      const pagination = createPagination({ total: 3, paidCount: 2 });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const paidLabels = screen.getAllByText("Paid");
+      const paidStatTitle = paidLabels.find((el) =>
+        el.classList.contains("stat-title")
+      );
+      expect(paidStatTitle).toBeInTheDocument();
+
+      const unpaidLabel = screen.getByText("Unpaid");
+      expect(unpaidLabel).toBeInTheDocument();
+
+      const paidStat = paidStatTitle?.closest(".stat");
+      expect(paidStat?.querySelector(".stat-value")).toHaveTextContent("2");
+
+      const unpaidStat = unpaidLabel.closest(".stat");
+      expect(unpaidStat?.querySelector(".stat-value")).toHaveTextContent("1");
+    });
+  });
+
+  describe("search functionality", () => {
+    it("renders search input", () => {
+      const submissions = [createSubmission("1")];
+      const pagination = createPagination({ total: 1 });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const searchInput = screen.getByPlaceholderText(
+        "Search by name, phone, or status..."
+      );
+      expect(searchInput).toBeInTheDocument();
+    });
+
+    it("shows clear button when search is active", () => {
+      const submissions = [createSubmission("1", { username: "alice" })];
+      const pagination = createPagination({ total: 1, search: "alice" });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const clearButton = screen.getByLabelText("Clear search");
+      expect(clearButton).toBeInTheDocument();
+    });
+
+    it("shows result count when search is active", () => {
+      const submissions = [createSubmission("1", { username: "alice" })];
+      const pagination = createPagination({ total: 1, search: "alice" });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      expect(
+        screen.getByText(/Showing 1 result for "alice"/)
+      ).toBeInTheDocument();
+    });
+
+    it("shows empty state when no results match", () => {
+      const submissions: ReturnType<typeof createSubmission>[] = [];
+      const pagination = createPagination({ total: 0, search: "xyz" });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      expect(
+        screen.getByText("No submissions match your search.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("pagination", () => {
+    it("shows pagination when items exceed page size", () => {
+      const submissions = Array.from({ length: 25 }, (_, i) =>
+        createSubmission(String(i + 1))
+      );
+      const pagination = createPagination({
+        total: 30,
+        pageSize: 25,
+        totalPages: 2,
+      });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      expect(screen.getByText("Showing 1-25 of 30")).toBeInTheDocument();
+      expect(screen.getByLabelText("Next page")).toBeInTheDocument();
+      expect(screen.getByLabelText("Previous page")).toBeInTheDocument();
+    });
+
+    it("does not show pagination controls when items fit on one page", () => {
+      const submissions = Array.from({ length: 10 }, (_, i) =>
+        createSubmission(String(i + 1))
+      );
+      const pagination = createPagination({
+        total: 10,
+        pageSize: 25,
+        totalPages: 1,
+      });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      expect(screen.queryByLabelText("Next page")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Previous page")).not.toBeInTheDocument();
+    });
+
+    it("disables previous button on first page", () => {
+      const submissions = Array.from({ length: 25 }, (_, i) =>
+        createSubmission(String(i + 1))
+      );
+      const pagination = createPagination({
+        page: 1,
+        total: 30,
+        pageSize: 25,
+        totalPages: 2,
+      });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const prevButton = screen.getByLabelText("Previous page");
+      expect(prevButton).toHaveClass("btn-disabled");
+    });
+
+    it("disables next button on last page", () => {
+      const submissions = Array.from({ length: 5 }, (_, i) =>
+        createSubmission(String(i + 26))
+      );
+      const pagination = createPagination({
+        page: 2,
+        total: 30,
+        pageSize: 25,
+        totalPages: 2,
+      });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const nextButton = screen.getByLabelText("Next page");
+      expect(nextButton).toHaveClass("btn-disabled");
+    });
+
+    it("shows correct range on second page", () => {
+      const submissions = Array.from({ length: 5 }, (_, i) =>
+        createSubmission(String(i + 26))
+      );
+      const pagination = createPagination({
+        page: 2,
+        total: 30,
+        pageSize: 25,
+        totalPages: 2,
+      });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      expect(screen.getByText("Showing 26-30 of 30")).toBeInTheDocument();
+    });
+
+    it("highlights current page", () => {
+      const submissions = Array.from({ length: 25 }, (_, i) =>
+        createSubmission(String(i + 1))
+      );
+      const pagination = createPagination({
+        page: 1,
+        total: 50,
+        pageSize: 25,
+        totalPages: 2,
+      });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const page1Button = screen.getByLabelText("Page 1");
+      expect(page1Button).toHaveClass("btn-active");
+      expect(page1Button).toHaveAttribute("aria-current", "page");
+    });
+  });
+
+  describe("empty states", () => {
+    it("shows empty message when no submissions", () => {
+      const pagination = createPagination({ total: 0 });
+      renderWithRouter(<Submissions submissions={[]} pagination={pagination} />);
+
+      expect(screen.getByText("No submissions yet.")).toBeInTheDocument();
+    });
+  });
+
+  describe("items per page", () => {
+    it("shows items per page selector", () => {
+      const submissions = [createSubmission("1")];
+      const pagination = createPagination({ total: 1, pageSize: 25 });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const selector = screen.getByLabelText("Items per page");
+      expect(selector).toBeInTheDocument();
+      expect(selector).toHaveValue("25");
+    });
+
+    it("shows all page size options", () => {
+      const submissions = [createSubmission("1")];
+      const pagination = createPagination({ total: 1 });
+      renderWithRouter(
+        <Submissions submissions={submissions} pagination={pagination} />
+      );
+
+      const selector = screen.getByLabelText("Items per page");
+      expect(selector.querySelectorAll("option")).toHaveLength(4);
+      expect(screen.getByRole("option", { name: "10" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "25" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "50" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "100" })).toBeInTheDocument();
+    });
+  });
+});

--- a/app/routes/sheets.$sheetId.admin/components/Submissions/index.tsx
+++ b/app/routes/sheets.$sheetId.admin/components/Submissions/index.tsx
@@ -1,37 +1,330 @@
+import { Form, useNavigation, useSearchParams } from "@remix-run/react";
+import { useRef, useEffect } from "react";
+import { IoSearch, IoClose } from "react-icons/io5";
 import SubmissionRow from "./SubmissionRow";
 
-export default function SheetStats({ submissions }) {
+type Submission = {
+  id: string;
+  isPaid: boolean;
+  createdAt: string;
+  sheetId: string;
+  sailor: {
+    username: string;
+    firstName: string | null;
+    lastName: string | null;
+    phone: string;
+  };
+};
+
+type Pagination = {
+  page: number;
+  pageSize: number;
+  total: number;
+  paidCount: number;
+  totalPages: number;
+  search: string;
+};
+
+type SubmissionsProps = {
+  submissions: Submission[];
+  pagination: Pagination;
+};
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+export default function Submissions({
+  submissions,
+  pagination,
+}: SubmissionsProps) {
+  const [searchParams] = useSearchParams();
+  const navigation = useNavigation();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  const { page, pageSize, total, paidCount, totalPages, search } = pagination;
+  const startIndex = (page - 1) * pageSize;
+  const endIndex = Math.min(startIndex + submissions.length, total);
+
+  const isLoading = navigation.state === "loading";
+  const isSearching =
+    navigation.location?.search.includes("search=") ||
+    navigation.location?.search.includes("page=");
+
+  // Build URL with updated params
+  const buildUrl = (updates: Record<string, string | number | null>) => {
+    const params = new URLSearchParams(searchParams);
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value === null || value === "" || (key === "page" && value === 1)) {
+        params.delete(key);
+      } else {
+        params.set(key, String(value));
+      }
+    });
+    return `?${params.toString()}`;
+  };
+
+  // Generate page numbers for pagination
+  const getPageNumbers = () => {
+    const pages: (number | string)[] = [];
+    const maxVisiblePages = 5;
+
+    if (totalPages <= maxVisiblePages) {
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      if (page <= 3) {
+        for (let i = 1; i <= 4; i++) pages.push(i);
+        pages.push("...");
+        pages.push(totalPages);
+      } else if (page >= totalPages - 2) {
+        pages.push(1);
+        pages.push("...");
+        for (let i = totalPages - 3; i <= totalPages; i++) pages.push(i);
+      } else {
+        pages.push(1);
+        pages.push("...");
+        for (let i = page - 1; i <= page + 1; i++) pages.push(i);
+        pages.push("...");
+        pages.push(totalPages);
+      }
+    }
+
+    return pages;
+  };
+
+  const showPagination = total > pageSize;
+  const unpaidCount = total - paidCount;
+
+  // Keep focus on search input during navigation
+  useEffect(() => {
+    if (!isLoading && searchInputRef.current) {
+      const input = searchInputRef.current;
+      if (document.activeElement !== input && search) {
+        input.focus();
+        input.setSelectionRange(input.value.length, input.value.length);
+      }
+    }
+  }, [isLoading, search]);
+
   return (
-    <>
-      <div className="flex">
-        <div className="stat">
-          <div className="stat-title">Total Submissions</div>
-          <div className="stat-value">{submissions.length}</div>
-        </div>
-        <div className="stat">
-          <div className="stat-title">Paid</div>
-          <div className="stat-value">
-            {submissions.filter((s) => s.isPaid).length}/{submissions.length}
+    <div className="card bg-base-100 shadow-xl">
+      <div className={`card-body gap-6 ${isSearching ? "opacity-60" : ""}`}>
+        {/* Stats Section */}
+        <div className="stats stats-vertical bg-base-200 sm:stats-horizontal">
+          <div className="stat">
+            <div className="stat-title">Total Submissions</div>
+            <div className="stat-value text-primary">{total}</div>
+          </div>
+          <div className="stat">
+            <div className="stat-title">Paid</div>
+            <div className="stat-value text-success">
+              {paidCount}
+              <span className="text-base-content/50 text-lg font-normal">
+                /{total}
+              </span>
+            </div>
+          </div>
+          <div className="stat">
+            <div className="stat-title">Unpaid</div>
+            <div className="stat-value text-warning">{unpaidCount}</div>
           </div>
         </div>
-      </div>
 
-      <div className="overflow-x-auto">
-        <table className="table">
-          <thead>
-            <tr>
-              <th>paid</th>
-              <th>name</th>
-              <th>created</th>
-            </tr>
-          </thead>
-          <tbody>
-            {submissions.map((submission) => (
-              <SubmissionRow key={submission.id} submission={submission} />
-            ))}
-          </tbody>
-        </table>
+        {/* Search Bar */}
+        <Form method="get" className="form-control">
+          {/* Preserve pageSize in search form */}
+          <input type="hidden" name="pageSize" value={pageSize} />
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-base-content/50">
+              <IoSearch size={20} />
+            </span>
+            <input
+              ref={searchInputRef}
+              type="text"
+              name="search"
+              placeholder="Search by name, phone, or status..."
+              className="input input-bordered w-full pl-10 pr-10"
+              defaultValue={search}
+              aria-label="Search submissions"
+              onChange={(e) => {
+                // Debounced submit on change
+                const form = e.currentTarget.form;
+                if (form) {
+                  if (debounceRef.current) {
+                    clearTimeout(debounceRef.current);
+                  }
+                  debounceRef.current = setTimeout(() => {
+                    form.requestSubmit();
+                  }, 300);
+                }
+              }}
+            />
+            {search && (
+              <a
+                href={buildUrl({ search: null, page: null })}
+                className="btn btn-ghost btn-sm btn-circle absolute right-2 top-1/2 -translate-y-1/2"
+                aria-label="Clear search"
+              >
+                <IoClose size={18} />
+              </a>
+            )}
+          </div>
+          {search && (
+            <div className="mt-2 text-sm text-base-content/70">
+              Showing {total} result{total !== 1 ? "s" : ""} for &quot;{search}
+              &quot;
+            </div>
+          )}
+        </Form>
+
+        {/* Table */}
+        <div className="overflow-x-auto rounded-lg border border-base-300">
+          <table className="table table-zebra">
+            <thead className="bg-base-200">
+              <tr>
+                <th className="font-semibold uppercase tracking-wide text-base-content/70">
+                  Paid
+                </th>
+                <th className="font-semibold uppercase tracking-wide text-base-content/70">
+                  Name
+                </th>
+                <th className="font-semibold uppercase tracking-wide text-base-content/70">
+                  Created
+                </th>
+                <th className="font-semibold uppercase tracking-wide text-base-content/70">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {submissions.length > 0 ? (
+                submissions.map((submission) => (
+                  <SubmissionRow key={submission.id} submission={submission} />
+                ))
+              ) : (
+                <tr>
+                  <td
+                    colSpan={4}
+                    className="py-12 text-center text-base-content/50"
+                  >
+                    {search
+                      ? "No submissions match your search."
+                      : "No submissions yet."}
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {showPagination && (
+          <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
+            {/* Items per page selector */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-base-content/70">Show</span>
+              <select
+                className="select select-bordered select-sm"
+                value={pageSize}
+                onChange={(e) => {
+                  window.location.href = buildUrl({
+                    pageSize: e.target.value,
+                    page: 1,
+                  });
+                }}
+                aria-label="Items per page"
+              >
+                {PAGE_SIZE_OPTIONS.map((size) => (
+                  <option key={size} value={size}>
+                    {size}
+                  </option>
+                ))}
+              </select>
+              <span className="text-sm text-base-content/70">per page</span>
+            </div>
+
+            {/* Page info */}
+            <div className="text-sm text-base-content/70">
+              Showing {startIndex + 1}-{endIndex} of {total}
+            </div>
+
+            {/* Page navigation */}
+            <div className="join">
+              <a
+                href={page > 1 ? buildUrl({ page: page - 1 }) : undefined}
+                className={`btn btn-sm join-item ${page === 1 ? "btn-disabled" : ""}`}
+                aria-label="Previous page"
+                aria-disabled={page === 1}
+              >
+                &laquo;
+              </a>
+              {getPageNumbers().map((pageNum, index) =>
+                pageNum === "..." ? (
+                  <span
+                    key={`ellipsis-${index}`}
+                    className="btn btn-sm join-item btn-disabled"
+                  >
+                    ...
+                  </span>
+                ) : (
+                  <a
+                    key={pageNum}
+                    href={buildUrl({ page: pageNum as number })}
+                    className={`btn btn-sm join-item ${
+                      page === pageNum ? "btn-active" : ""
+                    }`}
+                    aria-label={`Page ${pageNum}`}
+                    aria-current={page === pageNum ? "page" : undefined}
+                  >
+                    {pageNum}
+                  </a>
+                )
+              )}
+              <a
+                href={
+                  page < totalPages ? buildUrl({ page: page + 1 }) : undefined
+                }
+                className={`btn btn-sm join-item ${page === totalPages ? "btn-disabled" : ""}`}
+                aria-label="Next page"
+                aria-disabled={page === totalPages}
+              >
+                &raquo;
+              </a>
+            </div>
+          </div>
+        )}
+
+        {/* Show items per page selector even when pagination is not needed but there are items */}
+        {!showPagination && total > 0 && (
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-base-content/70">Show</span>
+              <select
+                className="select select-bordered select-sm"
+                value={pageSize}
+                onChange={(e) => {
+                  window.location.href = buildUrl({
+                    pageSize: e.target.value,
+                    page: 1,
+                  });
+                }}
+                aria-label="Items per page"
+              >
+                {PAGE_SIZE_OPTIONS.map((size) => (
+                  <option key={size} value={size}>
+                    {size}
+                  </option>
+                ))}
+              </select>
+              <span className="text-sm text-base-content/70">per page</span>
+            </div>
+            <div className="text-sm text-base-content/70">
+              Showing {total} of {total}
+            </div>
+          </div>
+        )}
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Modernized the admin sheet submissions interface with server-side pagination and real-time search filtering. Moved all filtering logic to the database layer using Prisma skip/take for efficient data fetching, and URL search params for preserving pagination state.

## Changes
- Added `readSheetSubmissionsPaginated()` function with support for search, pagination, and parallel queries
- Refactored Submissions component to use URL-based navigation instead of client-side state
- Enhanced SubmissionRow with better styling, hover states, and TypeScript types
- Comprehensive test coverage for pagination, search, and empty states

## Test plan
- Verified search filters by username, first/last name, phone, and paid status
- Tested pagination controls and page size selector
- Confirmed URL state preservation across navigation
- All 21 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)