### PR TITLE
BET-28: Redirect to submissions if already submitted

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,6 +1,6 @@
 import { LoaderFunctionArgs, redirect } from "@remix-run/node";
 import invariant from "tiny-invariant";
-import { readSailor } from "~/models/sailor.server";
+import { readSailorWithSheetSubmissions } from "~/models/sailor.server";
 import { readLatestSheet } from "~/models/sheet.server";
 import { authenticator } from "~/services/auth.server";
 
@@ -8,17 +8,26 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   let sailorId = await authenticator.isAuthenticated(request, {
     failureRedirect: "/login",
   });
-  const sailor = await readSailor(sailorId);
+
+  const latestSheet = await readLatestSheet();
+  invariant(latestSheet, "No sheet exists");
+
+  const sailor = await readSailorWithSheetSubmissions(sailorId, latestSheet.id);
 
   if (sailor === null) {
     await authenticator.logout(request, { redirectTo: "/login" });
     return;
   }
 
+  // If user has submissions, go to submissions list; otherwise check onboarding
+  if (sailor.submissions.length > 0) {
+    return redirect(`/sheets/${latestSheet.id}/submissions`);
+  }
+
+  // Only require onboarding for users without submissions
   if (!sailor.username || !sailor.profilePictureUrl) {
     return redirect("/onboard");
   }
-  const latestSheet = await readLatestSheet();
-  invariant(latestSheet, "No sheet exists");
-  return redirect(`/sheets/${latestSheet.id}`);
+
+  return redirect(`/sheets/${latestSheet.id}/submissions/new`);
 };


### PR DESCRIPTION
## Summary
- Redirect users to their submissions list if they have existing submissions for the latest sheet
- Skip onboarding requirement for users with existing submissions, even if profile is incomplete
- New users without submissions still go through onboarding before creating their first submission

## Changes
Updated the root route loader to check user submission status and route accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)