### PR TITLE
Allow camera roll selection on onboard upload

### DIFF
--- a/app/components/ProfilePictureUpload.tsx
+++ b/app/components/ProfilePictureUpload.tsx
@@ -142,7 +142,6 @@ export default function ProfilePictureUpload({
         ref={fileInputRef}
         type="file"
         accept="image/*"
-        capture="environment"
         onChange={handleFileChange}
         className="hidden"
         disabled={isUploading}


### PR DESCRIPTION
Removes the camera-only capture attribute so users can pick existing photos. This fixes onboard profile picture uploads on mobile.