### PR TITLE
BET-35: set page titles from active sheet

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,9 @@
-import { json, LinksFunction, LoaderFunctionArgs } from "@remix-run/node";
+import {
+  json,
+  LinksFunction,
+  LoaderFunctionArgs,
+  MetaFunction,
+} from "@remix-run/node";
 import {
   Links,
   Meta,
@@ -15,6 +20,20 @@ import { themeBootstrapScript } from "~/utils/theme";
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
 ];
+
+type MatchData = {
+  sheet?: {
+    title?: string | null;
+  };
+};
+
+export const meta: MetaFunction = ({ matches }) => {
+  const sheetTitle = matches
+    .map((match) => match.data as MatchData | undefined)
+    .find((data) => data?.sheet?.title)?.sheet?.title;
+
+  return [{ title: sheetTitle ?? "Bet Pirate" }];
+};
 
 const emptySailor: Sailor = {
   id: "",
@@ -47,7 +66,6 @@ export default function Root() {
           name="viewport"
           content="width=device-width,minimum-scale=1,viewport-fit=cover"
         />
-        <title>Bet Pirate - Superbowl LIX Prop Sheet</title>
         <script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
         <Meta />
         <Links />

--- a/app/routes/login/components/PhoneNumberForm.tsx
+++ b/app/routes/login/components/PhoneNumberForm.tsx
@@ -6,8 +6,10 @@ import PhoneNumberInput from "~/components/PhoneNumberInput";
 
 export default function PhoneNumberForm({
   error,
+  sheetTitle,
 }: {
   error?: { message?: string } | null;
+  sheetTitle?: string | null;
 }) {
   const [phone, setPhone] = useState<E164Number | undefined>(undefined);
   return (
@@ -30,9 +32,11 @@ export default function PhoneNumberForm({
             <div className="text-center text-2xl font-extrabold">
               Welcome to BetPirate!
             </div>
-            <div className="text-center text-lg font-extrabold">
-              Superbowl LIX Prop Sheet
-            </div>
+            {sheetTitle ? (
+              <div className="text-center text-lg font-extrabold">
+                {sheetTitle}
+              </div>
+            ) : null}
             <div className="divider" />
             <p className="text-center">Enter your phone number to get started</p>
             <label className="mt-2 block text-sm font-semibold">

--- a/app/routes/sheets.$sheetId/route.tsx
+++ b/app/routes/sheets.$sheetId/route.tsx
@@ -1,4 +1,4 @@
-import { json, LoaderFunctionArgs } from "@remix-run/node";
+import { json, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { Link, Outlet, useLoaderData, useLocation } from "@remix-run/react";
 import invariant from "tiny-invariant";
 import { readSailor } from "~/models/sailor.server";
@@ -23,6 +23,10 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   invariant(!!sheet, "No sheet exists with this id");
 
   return json({ sheet, sailor });
+};
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  return [{ title: data?.sheet?.title ?? "Bet Pirate" }];
 };
 
 export default function Sheet() {


### PR DESCRIPTION
Set document titles from the active sheet on sheet routes and login.\nReplace the hardcoded login subtitle with the latest sheet title.\nAdd a fallback to Bet Pirate when no sheet title is available.