### PR TITLE
Add payment reminder SMS on submission

### DIFF
--- a/app/routes/sheets.$sheetId.submissions.new/route.tsx
+++ b/app/routes/sheets.$sheetId.submissions.new/route.tsx
@@ -17,7 +17,10 @@ import { z } from "zod";
 import { parseWithZod } from "@conform-to/zod";
 import SheetInstructions from "./components/SheetInstructions";
 import { readSailor } from "~/models/sailor.server";
-import { sendSubmissionConfirmationSMS } from "~/services/sms.server";
+import {
+  sendSubmissionConfirmationSMS,
+  sendSubmissionPaymentReminderSMS,
+} from "~/services/sms.server";
 
 export const schema = z.object({
   selections: z.array(z.object({ optionId: z.string() })),
@@ -73,6 +76,11 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
     await sendSubmissionConfirmationSMS({
       phone: sailor.phone,
       sheetName: submission.sheet.title,
+    });
+    await sendSubmissionPaymentReminderSMS({
+      phone: sailor.phone,
+      sheetName: submission.sheet.title,
+      sheetOpensAt: submission.sheet.closesAt,
     });
   }
 

--- a/app/routes/sheets.$sheetId.submissions.new/route.tsx
+++ b/app/routes/sheets.$sheetId.submissions.new/route.tsx
@@ -17,10 +17,7 @@ import { z } from "zod";
 import { parseWithZod } from "@conform-to/zod";
 import SheetInstructions from "./components/SheetInstructions";
 import { readSailor } from "~/models/sailor.server";
-import {
-  sendSubmissionConfirmationSMS,
-  sendSubmissionPaymentReminderSMS,
-} from "~/services/sms.server";
+import { sendSubmissionConfirmationSMS } from "~/services/sms.server";
 
 export const schema = z.object({
   selections: z.array(z.object({ optionId: z.string() })),
@@ -76,11 +73,6 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
     await sendSubmissionConfirmationSMS({
       phone: sailor.phone,
       sheetName: submission.sheet.title,
-    });
-    await sendSubmissionPaymentReminderSMS({
-      phone: sailor.phone,
-      sheetName: submission.sheet.title,
-      sheetOpensAt: submission.sheet.closesAt,
     });
   }
 

--- a/app/services/sms.server.ts
+++ b/app/services/sms.server.ts
@@ -33,6 +33,22 @@ type SendConfirmationSMSOptions = {
   sheetName: string;
 };
 
+type SendPaymentReminderSMSOptions = {
+  phone: string;
+  sheetName: string;
+  sheetOpensAt?: string | Date | null;
+};
+
+const formatSheetOpensAt = (value?: string | Date | null) => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString("en-CA", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
 export let sendSubmissionConfirmationSMS = async (
   options: SendConfirmationSMSOptions,
 ) => {
@@ -52,5 +68,29 @@ export let sendSubmissionConfirmationSMS = async (
   } catch (e) {
     // Log the error but don't throw - SMS failure should not block submission
     console.error("Couldn't send confirmation SMS: ", e);
+  }
+};
+
+export let sendSubmissionPaymentReminderSMS = async (
+  options: SendPaymentReminderSMSOptions,
+) => {
+  const opensAtLabel = formatSheetOpensAt(options.sheetOpensAt);
+  const deadlineText = opensAtLabel ?? "the sheet opens";
+  const body = `Reminder: eTransfer $10 to hayz_149@hotmail.com before ${deadlineText} for your submission to "${options.sheetName}" to be valid.`;
+  try {
+    if (isProduction) {
+      const response = await sendTwilioSMS(options.phone, body);
+      await createSMS({ to: options.phone, body, response });
+    } else {
+      console.log(`[DummySMS] To: ${options.phone}, Body: ${body}`);
+      await createSMS({
+        to: options.phone,
+        body,
+        response: { message: "Dummy SMS (dev mode)" },
+      });
+    }
+  } catch (e) {
+    // Log the error but don't throw - SMS failure should not block submission
+    console.error("Couldn't send payment reminder SMS: ", e);
   }
 };

--- a/app/services/sms.server.ts
+++ b/app/services/sms.server.ts
@@ -33,26 +33,10 @@ type SendConfirmationSMSOptions = {
   sheetName: string;
 };
 
-type SendPaymentReminderSMSOptions = {
-  phone: string;
-  sheetName: string;
-  sheetOpensAt?: string | Date | null;
-};
-
-const formatSheetOpensAt = (value?: string | Date | null) => {
-  if (!value) return null;
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toLocaleString("en-CA", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  });
-};
-
 export let sendSubmissionConfirmationSMS = async (
   options: SendConfirmationSMSOptions,
 ) => {
-  const body = `Ahoy! Your picks for "${options.sheetName}" have been received. Good luck, matey!\n\nFollow along live at https://betpirate.ca`;
+  const body = `Ahoy! Your picks for "${options.sheetName}" have been received. Good luck, matey!\n\nReminder: eTransfer $10 to hayz_149@hotmail.com before the sheet opens for your submission to be valid.\n\nFollow along live at https://betpirate.ca`;
   try {
     if (isProduction) {
       const response = await sendTwilioSMS(options.phone, body);
@@ -68,29 +52,5 @@ export let sendSubmissionConfirmationSMS = async (
   } catch (e) {
     // Log the error but don't throw - SMS failure should not block submission
     console.error("Couldn't send confirmation SMS: ", e);
-  }
-};
-
-export let sendSubmissionPaymentReminderSMS = async (
-  options: SendPaymentReminderSMSOptions,
-) => {
-  const opensAtLabel = formatSheetOpensAt(options.sheetOpensAt);
-  const deadlineText = opensAtLabel ?? "the sheet opens";
-  const body = `Reminder: eTransfer $10 to hayz_149@hotmail.com before ${deadlineText} for your submission to "${options.sheetName}" to be valid.`;
-  try {
-    if (isProduction) {
-      const response = await sendTwilioSMS(options.phone, body);
-      await createSMS({ to: options.phone, body, response });
-    } else {
-      console.log(`[DummySMS] To: ${options.phone}, Body: ${body}`);
-      await createSMS({
-        to: options.phone,
-        body,
-        response: { message: "Dummy SMS (dev mode)" },
-      });
-    }
-  } catch (e) {
-    // Log the error but don't throw - SMS failure should not block submission
-    console.error("Couldn't send payment reminder SMS: ", e);
   }
 };


### PR DESCRIPTION
Adds a second SMS after submission that reminds sailors to eTransfer . Message includes the sheet title and a formatted deadline. SMS failure is logged without blocking submission.