### PR TITLE
Fix deterministic theme bootstrap

### DIFF
--- a/app/utils/theme.ts
+++ b/app/utils/theme.ts
@@ -1,10 +1,36 @@
 export const themeBootstrapScript = `(() => {
+  const prefersDark = window.matchMedia
+    ? window.matchMedia('(prefers-color-scheme: dark)').matches
+    : false;
+  const validThemes = ['lemonade', 'abyss'];
+  const legacyMap = {
+    light: 'lemonade',
+    dark: 'abyss',
+  };
+  let stored = null;
+
   try {
-    const stored = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = stored || (prefersDark ? 'abyss' : 'lemonade');
-    document.documentElement.dataset.theme = theme;
+    stored = localStorage.getItem('theme');
   } catch (error) {
-    // ignore storage or media query errors
+    // ignore storage errors
+  }
+
+  const normalized = legacyMap[stored] || stored;
+  const isValid = typeof normalized === 'string' && validThemes.includes(normalized);
+  const theme = isValid ? normalized : (prefersDark ? 'abyss' : 'lemonade');
+  document.documentElement.dataset.theme = theme;
+
+  if (stored !== null && stored !== normalized) {
+    try {
+      localStorage.setItem('theme', normalized);
+    } catch (error) {
+      // ignore storage errors
+    }
+  } else if (stored !== null && !isValid) {
+    try {
+      localStorage.removeItem('theme');
+    } catch (error) {
+      // ignore storage errors
+    }
   }
 })();`;


### PR DESCRIPTION
Make the theme bootstrap deterministic by validating stored values and mapping legacy light/dark to the current themes. Also fall back to prefers-color-scheme when storage is unavailable or invalid. This prevents random-looking theme selection on page load.