### PR TITLE
BET-38: Fix CI test failures by mocking database dependency

### DIFF
--- a/app/routes/login/__tests__/loader.tsx
+++ b/app/routes/login/__tests__/loader.tsx
@@ -1,7 +1,16 @@
+import { readLatestSheet } from "~/models/sheet.server";
 import { loader } from "../route";
+
+jest.mock("~/models/sheet.server", () => ({
+  readLatestSheet: jest.fn(),
+}));
 
 describe("login loader", () => {
   it("should return a response", async () => {
+    const mockReadLatestSheet = readLatestSheet as jest.MockedFunction<
+      typeof readLatestSheet
+    >;
+    mockReadLatestSheet.mockResolvedValue(null);
     const response = await loader({
       request: new Request("http://app.com/path"),
       params: {},


### PR DESCRIPTION
The login loader test was failing in CI due to a missing DATABASE_URL environment variable. The loader calls readLatestSheet which requires database access.

This fix mocks the readLatestSheet dependency in the test, allowing it to pass without requiring an actual database connection. All tests now pass.

## Test Results
- All 21 tests passing across 4 test suites
- No database connection required for unit tests

🤖 Generated with Claude Code