### PR TITLE
BET-43: Profile image improvements

### DIFF
--- a/app/routes/onboard.picture.tsx
+++ b/app/routes/onboard.picture.tsx
@@ -1,0 +1,112 @@
+import { parseWithZod } from "@conform-to/zod";
+import {
+  ActionFunctionArgs,
+  json,
+  LoaderFunctionArgs,
+  redirect,
+} from "@remix-run/node";
+import { Form, Link, useLoaderData } from "@remix-run/react";
+import { useState } from "react";
+import invariant from "tiny-invariant";
+import { z } from "zod";
+import ProfilePictureUpload from "~/components/ProfilePictureUpload";
+import { readSailor, updateSailor } from "~/models/sailor.server";
+import { readLatestSheet } from "~/models/sheet.server";
+import { authenticator } from "~/services/auth.server";
+
+export const schema = z.object({
+  profilePictureUrl: z.string().optional(),
+});
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const sailorId = await authenticator.isAuthenticated(request, {
+    failureRedirect: "/login",
+  });
+  const sailor = await readSailor(sailorId);
+  if (!sailor) return redirect("/login");
+
+  // If user hasn't set username yet, redirect to step 1
+  if (!sailor.username) {
+    return redirect("/onboard");
+  }
+
+  const latestSheet = await readLatestSheet();
+  invariant(latestSheet, "No sheet exists");
+
+  return json({
+    sailor: {
+      ...sailor,
+      profilePictureUrl: sailor.profilePictureUrl ?? null,
+    },
+    latestSheetId: latestSheet.id,
+  });
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const sailorId = await authenticator.isAuthenticated(request, {
+    failureRedirect: "/login",
+  });
+
+  const formData = await request.formData();
+  const sailorForm = parseWithZod(formData, { schema });
+
+  invariant(sailorForm.status === "success", `missing required parameters`);
+
+  const profilePictureUrl = sailorForm.value.profilePictureUrl?.trim();
+
+  await updateSailor(sailorId, {
+    profilePictureUrl: profilePictureUrl ? profilePictureUrl : null,
+  });
+
+  const latestSheet = await readLatestSheet();
+  invariant(latestSheet, "No sheet exists");
+  return redirect(`/sheets/${latestSheet.id}/submissions/new`);
+};
+
+export default function OnBoardPicture() {
+  const { sailor, latestSheetId } = useLoaderData<typeof loader>();
+  const [profilePictureUrl, setProfilePictureUrl] = useState<string | null>(
+    sailor.profilePictureUrl || null,
+  );
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="card card-sm w-96 max-w-[90vw]">
+        <Form
+          className="flex flex-col space-y-4 card-body"
+          action="/onboard/picture"
+          method="post"
+        >
+          <div className="pt-6 text-center text-xl font-extrabold">
+            Add yer picture, Matey
+          </div>
+
+          <ProfilePictureUpload
+            onImageChange={setProfilePictureUrl}
+            currentImage={sailor.profilePictureUrl}
+          />
+          <input
+            type="hidden"
+            name="profilePictureUrl"
+            value={profilePictureUrl || ""}
+          />
+
+          <button
+            type="submit"
+            className="btn btn-primary w-full"
+            disabled={!profilePictureUrl}
+          >
+            Add a picture and proceed
+          </button>
+
+          <Link
+            to={`/sheets/${latestSheetId}/submissions/new`}
+            className="text-center text-sm text-base-content/60 hover:text-base-content"
+          >
+            nay, I be ashamed o' me appearance
+          </Link>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/sheets.$sheetId/route.tsx
+++ b/app/routes/sheets.$sheetId/route.tsx
@@ -39,11 +39,18 @@ export default function Sheet() {
       <header className="w-full flex items-center justify-between p-4">
         <div className="w-12">
           <Link to={`/sheets/${sheet.id}`}>
-            <Logo size={"38px"} />
+            <div className="w-10 h-10 rounded-full overflow-hidden ring ring-primary ring-offset-base-100 ring-offset-1">
+              <img
+                src={sailor?.profilePictureUrl || "/fallback-avatar.svg"}
+                alt={sailor?.username || "User"}
+                className="w-full h-full object-cover"
+              />
+            </div>
           </Link>
         </div>
-        <Link to={`/sheets/${sheet.id}`}>
-          <h1 className="text-2xl font-black text-center">{sheet.title}</h1>
+        <Link to={`/sheets/${sheet.id}`} className="flex items-center">
+          <Logo size={"48px"} />
+          <h1 className="text-xl font-black uppercase pr-2">Betpirate</h1>
         </Link>
         <div className="w-12">
           <ThemeToggle />


### PR DESCRIPTION
## Summary
- Split onboarding flow into two separate steps for better profile picture adoption
- Step 1 collects user info (first name, last name, username)
- Step 2 focuses on profile picture upload with optional skip
- Updated navigation bar to display user avatar instead of logo
- Centered Betpirate branding in navigation

## Changes
- Created new `/onboard/picture` route for profile picture upload
- Modified `/onboard` to only collect user information
- Profile picture upload button disabled until picture is selected
- Navigation now shows user avatar on left, Betpirate branding in center

🤖 Generated with [Claude Code](https://claude.com/claude-code)