### PR TITLE
BET-40: Add prize pool display and improve leaderboard UX

### DIFF
--- a/app/routes/sheets.$sheetId.leaders/components/LeaderBoard/index.tsx
+++ b/app/routes/sheets.$sheetId.leaders/components/LeaderBoard/index.tsx
@@ -1,18 +1,40 @@
 import { Sailor, Sheet } from "@prisma/client";
 import { Link } from "@remix-run/react";
-import { IoTrophyOutline } from "react-icons/io5";
+import { IoCashOutline, IoTrophyOutline } from "react-icons/io5";
 import Ordinal from "~/components/Ordinal";
 import { SheetLeader } from "~/models/sheet.server";
+
+const calculatePrizePool = (paidCount: number) => {
+  const ENTRY_FEE = 10;
+  const RAKE = 0.2;
+  const WINNER_SHARE = 0.9;
+  const LOSER_SHARE = 0.1;
+
+  const totalPot = paidCount * ENTRY_FEE;
+  const afterRake = totalPot * (1 - RAKE);
+  const winnerPrize = afterRake * WINNER_SHARE;
+  const loserPrize = afterRake * LOSER_SHARE;
+
+  return {
+    totalPot,
+    afterRake,
+    winnerPrize,
+    loserPrize,
+  };
+};
 
 export default function LeaderBoard({
   sailor,
   sheet,
   leaders,
+  paidCount,
 }: {
   sailor: Sailor;
   sheet: Sheet;
   leaders: SheetLeader[];
+  paidCount: number;
 }) {
+  const prizePool = calculatePrizePool(paidCount);
   const groupedLeaders = leaders.reduce((acc, leader) => {
     const rankingGroup = acc.find((group) => group.ranking === leader.ranking);
     if (rankingGroup) {
@@ -46,10 +68,64 @@ export default function LeaderBoard({
       <div className="max-w-4xl mx-auto px-4 py-6">
         <div className="mb-6">
           <h1 className="text-3xl font-black mb-2 flex items-center gap-2">
-            <IoTrophyOutline className="text-primary" />
             Leaderboard
           </h1>
           <p className="opacity-70">Top performers for {sheet.title}</p>
+        </div>
+
+        <div className="stats stats-vertical sm:stats-horizontal shadow bg-base-100 w-full mb-6">
+          <div className="stat">
+            <div className="stat-figure text-success">
+              <IoCashOutline size={32} />
+            </div>
+            <div className="stat-title">Total Prize Pool</div>
+            <div className="stat-value text-success">
+              ${prizePool.afterRake.toFixed(0)}
+            </div>
+            <div className="stat-desc">
+              {paidCount} paid entries • 20% rake applied
+            </div>
+          </div>
+          <div className="stat">
+            <div className="stat-figure text-warning">
+              <IoTrophyOutline size={32} />
+            </div>
+            <div className="stat-title">1st Place Prize</div>
+            <div className="stat-value text-warning">
+              ${prizePool.winnerPrize.toFixed(0)}
+            </div>
+            <div className="stat-desc">90% of prize pool</div>
+          </div>
+          <div className="stat">
+            <div className="stat-figure text-info">
+              <IoTrophyOutline size={32} />
+            </div>
+            <div className="stat-title">Last Place Prize</div>
+            <div className="stat-value text-info">
+              ${prizePool.loserPrize.toFixed(0)}
+            </div>
+            <div className="stat-desc">10% of prize pool</div>
+          </div>
+        </div>
+
+        <div className="alert alert-info shadow-lg mb-6">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            className="stroke-current shrink-0 w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            ></path>
+          </svg>
+          <span>
+            <strong>Tip:</strong> Click on any sailor below to view their full
+            submission
+          </span>
         </div>
 
         <div className="space-y-6">
@@ -78,7 +154,8 @@ export default function LeaderBoard({
                     <Link
                       key={leader.submissionId}
                       to={`/sheets/${sheet.id}/submissions/${leader.submissionId}`}
-                      className="flex flex-col items-center gap-3 p-4 rounded-lg bg-base-200 hover:bg-base-300 transition-all hover:scale-105 cursor-pointer shadow-md hover:shadow-xl"
+                      className="flex flex-col items-center gap-3 p-4 rounded-lg bg-base-200 hover:bg-primary hover:text-primary-content transition-all hover:scale-105 cursor-pointer shadow-md hover:shadow-xl border-2 border-transparent hover:border-primary"
+                      title={`View ${leader.username}'s submission`}
                     >
                       <div className="relative">
                         <img
@@ -91,7 +168,9 @@ export default function LeaderBoard({
                           className="sm:w-20 sm:h-20 w-16 h-16 rounded-full object-cover ring-4 ring-base-300 bg-accent"
                         />
                         {sailor.id === leader.sailorId && (
-                          <span className="badge badge-primary badge-xs absolute -bottom-1.5 -right-1.5">you</span>
+                          <span className="badge badge-primary badge-xs absolute -bottom-1.5 -right-1.5">
+                            you
+                          </span>
                         )}
                       </div>
                       <div className="text-center w-full">


### PR DESCRIPTION
## Summary

Added prize pool calculations and improved leaderboard user experience to fulfill BET-40 requirements:

- **Prize Pool Display**: Shows total prize pool (with 20% rake), 1st place prize (90%), and last place prize (10%) in metrics section for both open and closed leaderboards
- **Entry Fee Calculation**: $10 per entry, paid entries only
- **Improved Clickability**: Added helpful tip alert on closed leaderboard and enhanced visual styling (primary color hover, border highlight, tooltip)
- **Cleaner Metrics**: Removed redundant "Your Entries" stat from open leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)