### PR TITLE
BET-41: Enhance submission comparison view with improved UX

### DIFF
--- a/app/models/submission.server.ts
+++ b/app/models/submission.server.ts
@@ -153,6 +153,37 @@ export const readSheetSubmission = (sheetId: string, sailorId: string) => {
   });
 };
 
+export const readSheetSailorSubmissions = (
+  sheetId: string,
+  sailorId: string
+) => {
+  return db.submission.findMany({
+    where: { sheetId, sailorId },
+    include: {
+      sailor: true,
+      selections: {
+        orderBy: {
+          option: {
+            proposition: {
+              order: "asc",
+            },
+          },
+        },
+        include: {
+          option: {
+            include: {
+              proposition: true,
+            },
+          },
+        },
+      },
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+};
+
 export const readSheetSubmissions = (sheetId: string) => {
   return db.submission.findMany({
     where: { sheetId },

--- a/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionComparison/index.tsx
+++ b/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionComparison/index.tsx
@@ -1,0 +1,174 @@
+import { IoCheckmark, IoClose } from "react-icons/io5";
+
+type SelectionStatus = "pending" | "correct" | "incorrect";
+
+interface PropositionOption {
+  id: string;
+  title: string;
+  shortTitle: string | null;
+  order: number | null;
+  propositionId: string;
+}
+
+interface Proposition {
+  id: string;
+  title: string;
+  shortTitle: string | null;
+  subtitle: string | null;
+  order: number | null;
+  answerId: string | null;
+  options: PropositionOption[];
+}
+
+interface Sheet {
+  propositions: Proposition[];
+}
+
+interface Selection {
+  id: string;
+  optionId: string;
+  option: {
+    proposition: Proposition;
+  };
+}
+
+interface Submission {
+  sailor: {
+    username: string | null;
+  };
+  selections: Selection[];
+}
+
+export default function SubmissionComparison({
+  sheet,
+  viewedSubmission,
+  activeSailorSubmission,
+}: {
+  sheet: Sheet;
+  viewedSubmission: Submission;
+  activeSailorSubmission: Submission | null;
+}) {
+  // Create maps for quick lookup
+  const viewedSelectionMap = new Map(
+    viewedSubmission.selections.map((sel) => [
+      sel.option.proposition.id,
+      sel.optionId,
+    ]),
+  );
+
+  const activeSailorSelectionMap = activeSailorSubmission
+    ? new Map(
+        activeSailorSubmission.selections.map((sel) => [
+          sel.option.proposition.id,
+          sel.optionId,
+        ]),
+      )
+    : null;
+
+  const getStatus = (
+    propositionId: string,
+    answerId: string | null,
+    selectedOptionId: string | undefined,
+  ): SelectionStatus => {
+    if (!answerId || !selectedOptionId) return "pending";
+    return selectedOptionId === answerId ? "correct" : "incorrect";
+  };
+
+  const renderOption = (
+    proposition: Proposition,
+    selectedOptionId: string | undefined,
+  ) => {
+    const selectedOption = proposition.options.find(
+      (opt: PropositionOption) => opt.id === selectedOptionId,
+    );
+    const status = getStatus(
+      proposition.id,
+      proposition.answerId,
+      selectedOptionId,
+    );
+
+    if (!selectedOption) {
+      return <span className="text-base-content/50 italic">No pick</span>;
+    }
+
+    const statusIcon =
+      status === "correct" ? (
+        <IoCheckmark className="text-success" />
+      ) : status === "incorrect" ? (
+        <IoClose className="text-error" />
+      ) : null;
+
+    const statusColor =
+      status === "correct"
+        ? "text-success font-bold"
+        : status === "incorrect"
+        ? "text-error"
+        : "text-base-content";
+
+    return (
+      <div className="flex items-center gap-2">
+        {statusIcon}
+        <span className={statusColor}>
+          {selectedOption.shortTitle || selectedOption.title}
+        </span>
+      </div>
+    );
+  };
+
+  const sortedPropositions = [...sheet.propositions].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0),
+  );
+
+  return (
+    <div className="mb-6">
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
+        {sortedPropositions.map((proposition) => {
+          const viewedOptionId = viewedSelectionMap.get(proposition.id);
+          const activeSailorOptionId = activeSailorSelectionMap?.get(
+            proposition.id,
+          );
+          return (
+            <div
+              key={proposition.id}
+              className="card card-bordered bg-base-100 shadow-md"
+            >
+              <div className="card-body p-4">
+                <div className="text-xs font-semibold uppercase opacity-60 mb-2">
+                  {proposition.shortTitle || proposition.title}
+                </div>
+
+                {proposition.subtitle && (
+                  <p className="opacity-70 text-xs mb-3">
+                    {proposition.subtitle}
+                  </p>
+                )}
+
+                <div className="space-y-3">
+                  <div>
+                    <div className="text-xs font-semibold opacity-60 mb-1">
+                      {viewedSubmission.sailor.username}
+                    </div>
+                    <div className="text-sm">
+                      {renderOption(proposition, viewedOptionId)}
+                    </div>
+                  </div>
+
+                  {activeSailorSubmission && (
+                    <div>
+                      <div className="text-xs font-semibold opacity-60 mb-1">
+                        You
+                      </div>
+                      <div className="text-sm">
+                        {renderOption(proposition, activeSailorOptionId)}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionHeader.tsx
+++ b/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionHeader.tsx
@@ -1,9 +1,11 @@
 export default function SubmissionHeader({
   username,
+  profilePictureUrl,
   isOwner,
   canEdit,
 }: {
   username: string | null;
+  profilePictureUrl: string | null;
   isOwner: boolean;
   canEdit: boolean;
 }) {
@@ -11,7 +13,18 @@ export default function SubmissionHeader({
 
   return (
     <>
-      <h1 className="text-3xl font-black mb-3">{title}</h1>
+      <div className="flex items-center gap-4 mb-4">
+        {!isOwner && (
+          <img
+            src={profilePictureUrl ?? "/fallback-avatar.svg"}
+            alt={username ?? "Sailor"}
+            width={64}
+            height={64}
+            className="w-16 h-16 rounded-full object-cover ring-4 ring-primary bg-accent shadow-lg"
+          />
+        )}
+        <h1 className="text-3xl font-black">{title}</h1>
+      </div>
       {isOwner && (
         <div className="alert shadow-lg mb-4">
           <span className="text-sm">

--- a/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionProgressBars/index.tsx
+++ b/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionProgressBars/index.tsx
@@ -1,0 +1,130 @@
+interface Selection {
+  id: string;
+  optionId: string;
+  option: {
+    id: string;
+    proposition: {
+      id: string;
+      order: number | null;
+      answerId: string | null;
+    };
+  };
+}
+
+interface Submission {
+  sailor: {
+    username: string | null;
+  };
+  selections: Selection[];
+}
+
+interface ProgressStats {
+  correct: number;
+  incorrect: number;
+  pending: number;
+  total: number;
+}
+
+function calculateStats(selections: Selection[]): ProgressStats {
+  let correct = 0;
+  let incorrect = 0;
+  let pending = 0;
+
+  selections.forEach((sel) => {
+    const proposition = sel.option.proposition;
+    if (!proposition.answerId) {
+      pending++;
+    } else if (sel.optionId === proposition.answerId) {
+      correct++;
+    } else {
+      incorrect++;
+    }
+  });
+
+  return {
+    correct,
+    incorrect,
+    pending,
+    total: selections.length,
+  };
+}
+
+function ProgressBar({
+  label,
+  stats,
+}: {
+  label: string;
+  stats: ProgressStats;
+}) {
+  const correctPercent = (stats.correct / stats.total) * 100;
+  const incorrectPercent = (stats.incorrect / stats.total) * 100;
+  const pendingPercent = (stats.pending / stats.total) * 100;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-semibold">{label}</span>
+        <span className="text-xs opacity-70">
+          <span className="text-success font-bold">{stats.correct}</span>
+          {" / "}
+          <span className="text-error font-bold">{stats.incorrect}</span>
+          {" / "}
+          <span className="text-warning font-bold">{stats.pending}</span>
+        </span>
+      </div>
+      <div className="flex h-6 rounded-lg overflow-hidden bg-base-300">
+        {stats.correct > 0 && (
+          <div
+            className="bg-success flex items-center justify-center text-success-content text-xs font-bold"
+            style={{ width: `${correctPercent}%` }}
+          >
+            {stats.correct > 0 && stats.correct}
+          </div>
+        )}
+        {stats.incorrect > 0 && (
+          <div
+            className="bg-error flex items-center justify-center text-error-content text-xs font-bold"
+            style={{ width: `${incorrectPercent}%` }}
+          >
+            {stats.incorrect > 0 && stats.incorrect}
+          </div>
+        )}
+        {stats.pending > 0 && (
+          <div
+            className="bg-warning flex items-center justify-center text-warning-content text-xs font-bold"
+            style={{ width: `${pendingPercent}%` }}
+          >
+            {stats.pending > 0 && stats.pending}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function SubmissionProgressBars({
+  viewedSubmission,
+  activeSailorSubmission,
+}: {
+  viewedSubmission: Submission;
+  activeSailorSubmission: Submission | null;
+}) {
+  const viewedStats = calculateStats(viewedSubmission.selections);
+  const activeSailorStats = activeSailorSubmission
+    ? calculateStats(activeSailorSubmission.selections)
+    : null;
+
+  return (
+    <div className="card card-bordered bg-base-100 shadow-md mb-6">
+      <div className="card-body p-4 space-y-3">
+        <ProgressBar
+          label={viewedSubmission.sailor.username || "Submission"}
+          stats={viewedStats}
+        />
+        {activeSailorSubmission && activeSailorStats && (
+          <ProgressBar label="You" stats={activeSailorStats} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionSelector/index.tsx
+++ b/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionSelector/index.tsx
@@ -1,0 +1,86 @@
+import { useSearchParams } from "@remix-run/react";
+
+interface Submission {
+  id: string;
+  createdAt: string;
+  nickname: string | null;
+}
+
+export default function SubmissionSelector({
+  submissions,
+  selectedSubmissionId,
+}: {
+  submissions: Submission[];
+  selectedSubmissionId: string | null;
+}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  if (submissions.length <= 1) {
+    return null;
+  }
+
+  const handleChange = (submissionId: string) => {
+    const newParams = new URLSearchParams(searchParams);
+    if (submissionId) {
+      newParams.set("compare", submissionId);
+    } else {
+      newParams.delete("compare");
+    }
+    setSearchParams(newParams, { replace: true });
+  };
+
+  return (
+    <div className="card card-bordered bg-base-100 shadow-md mb-4">
+      <div className="card-body p-4">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            className="stroke-primary shrink-0 w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <div className="flex-1">
+            <div className="text-sm font-semibold mb-1">
+              You have {submissions.length} submissions
+            </div>
+            <div className="text-xs opacity-70">
+              Select which submission to compare with:
+            </div>
+          </div>
+          <select
+            className="select select-bordered select-sm w-full sm:w-auto bg-base-200"
+            value={selectedSubmissionId || submissions[0]?.id || ""}
+            onChange={(e) => handleChange(e.target.value)}
+          >
+            {submissions.map((submission, index) => {
+              const label =
+                submission.nickname ||
+                `Submission ${submissions.length - index}`;
+              const date = new Date(submission.createdAt).toLocaleDateString(
+                "en-US",
+                {
+                  month: "short",
+                  day: "numeric",
+                  hour: "numeric",
+                  minute: "2-digit",
+                }
+              );
+              return (
+                <option key={submission.id} value={submission.id}>
+                  {label} - {date}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionTitle/index.tsx
+++ b/app/routes/sheets.$sheetId.submissions.$submissionId/components/SubmissionTitle/index.tsx
@@ -1,0 +1,149 @@
+import { useFetcher } from "@remix-run/react";
+import { useEffect, useState } from "react";
+import Ordinal from "~/components/Ordinal";
+
+export default function SubmissionTitle({
+  submissionLabel,
+  nickname,
+  initialValue,
+  canEdit,
+  submissionRank,
+  showRank,
+}: {
+  submissionLabel: string;
+  nickname: string | null;
+  initialValue: number;
+  canEdit: boolean;
+  submissionRank?: { correctCount: number; tieCount: number; rank: number };
+  showRank: boolean;
+}) {
+  const tieBreakerFetcher = useFetcher();
+  const nicknameFetcher = useFetcher();
+  const [value, setValue] = useState<number>(initialValue);
+  const [isEditing, setIsEditing] = useState(false);
+  const [nicknameValue, setNicknameValue] = useState(nickname ?? "");
+  const [isEditingNickname, setIsEditingNickname] = useState(false);
+
+  useEffect(() => {
+    const data = tieBreakerFetcher.data as { ok?: boolean } | undefined;
+    if (tieBreakerFetcher.state === "idle" && data?.ok) {
+      setIsEditing(false);
+    }
+  }, [tieBreakerFetcher.data, tieBreakerFetcher.state]);
+
+  useEffect(() => {
+    const data = nicknameFetcher.data as { ok?: boolean } | undefined;
+    if (nicknameFetcher.state === "idle" && data?.ok) {
+      setIsEditingNickname(false);
+    }
+  }, [nicknameFetcher.data, nicknameFetcher.state]);
+
+  const displayName = nicknameValue.trim() || submissionLabel;
+
+  return (
+    <div className="card card-bordered bg-base-100 shadow-md mb-6">
+      <div className="card-body">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex-1">
+            <div className="text-xs font-semibold uppercase opacity-60">
+              Submission
+            </div>
+            {canEdit ? (
+              isEditingNickname ? (
+                <nicknameFetcher.Form
+                  method="post"
+                  className="flex items-center gap-2 mt-1"
+                >
+                  <input type="hidden" name="intent" value="nickname" />
+                  <input
+                    type="text"
+                    name="nickname"
+                    className="input input-bordered w-48"
+                    value={nicknameValue}
+                    onChange={(event) => setNicknameValue(event.target.value)}
+                    placeholder="Add a nickname"
+                  />
+                  <button className="btn btn-primary btn-sm" type="submit">
+                    {nicknameFetcher.state === "submitting"
+                      ? "Saving..."
+                      : "Save"}
+                  </button>
+                </nicknameFetcher.Form>
+              ) : (
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm mt-1"
+                  onClick={() => setIsEditingNickname(true)}
+                >
+                  <span className="text-base font-bold">{displayName}</span>
+                  <span className="text-xs opacity-60 ml-2">
+                    {nicknameValue.trim() ? "Edit" : "Add nickname"}
+                  </span>
+                </button>
+              )
+            ) : (
+              <div className="text-lg font-bold mt-1">{displayName}</div>
+            )}
+          </div>
+
+          {showRank && submissionRank && (
+            <div className="text-center">
+              <div className="text-xs font-semibold uppercase opacity-60">
+                Rank
+              </div>
+              <div className="text-2xl font-black mt-1">
+                {submissionRank.tieCount > 0 ? "T" : ""}
+                <Ordinal number={submissionRank.rank} />
+              </div>
+              {submissionRank.tieCount > 0 && (
+                <div className="text-xs opacity-60 mt-1">
+                  with {submissionRank.tieCount} others
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="text-right">
+            <div className="text-xs font-semibold uppercase opacity-60">
+              Tie Breaker
+            </div>
+            {canEdit ? (
+              isEditing ? (
+                <tieBreakerFetcher.Form
+                  method="post"
+                  className="flex items-center gap-2 justify-end mt-1"
+                >
+                  <input type="hidden" name="intent" value="tieBreaker" />
+                  <input
+                    type="number"
+                    name="tieBreaker"
+                    className="input input-bordered w-28"
+                    inputMode="numeric"
+                    value={value}
+                    onChange={(event) => setValue(Number(event.target.value))}
+                  />
+                  <button className="btn btn-primary btn-sm" type="submit">
+                    {tieBreakerFetcher.state === "submitting"
+                      ? "Saving..."
+                      : "Save"}
+                  </button>
+                </tieBreakerFetcher.Form>
+              ) : (
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm mt-1"
+                  onClick={() => setIsEditing(true)}
+                >
+                  <span className="text-lg font-black">{value}</span>
+                  <span className="text-xs opacity-60 ml-2">Edit</span>
+                </button>
+              )
+            ) : (
+              <div className="text-2xl font-black mt-1">{value}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Enhanced the submission comparison view with significant UX improvements for viewing and comparing submissions between sailors.

## Key Features

### 1. Avatar Display
- Shows the viewed sailor's avatar in the header when viewing another sailor's submission
- Avatar has a primary ring border and shadow for visual emphasis

### 2. Stacked Progress Bars
- Visual comparison with horizontal bar charts showing:
  - 🟢 Green: Correct answers
  - 🔴 Red: Incorrect answers  
  - 🟡 Yellow: Pending/not yet graded
- Shows both viewed submission and active sailor's submission side-by-side
- Displays numerical breakdown for quick reference

### 3. Multi-Submission Selector
- Allows users with multiple submissions to choose which one to compare
- Dropdown with submission nicknames and timestamps
- Selection persists via URL query params (`?compare=submissionId`)
- Only displays when user has 2+ submissions

### 4. Tiled Comparison Grid
- Grid layout (2 cols on mobile, 5 cols on desktop) for better space usage
- Each card shows:
  - Question title
  - Both sailors' picks with status indicators (✓/✗)
  - Color-coded based on correctness
- Compact design removes question numbers to save space

### 5. Component Reorganization
- Renamed `TieBreakerCard` to `SubmissionTitle`
- Consolidated rank display into title card
- Removed `TotalsCard` component
- Simplified `SelectionsGrid` to only handle editing mode

## Technical Changes
- Added `readSheetSailorSubmissions()` model function
- Clear separation of editing vs viewing modes
- Improved dark mode compatibility
- Type-safe component interfaces

## Testing
- Tested viewing own submission in OPEN/CLOSED states
- Tested viewing other sailors' submissions
- Tested multi-submission selection
- Verified dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)