### PR TITLE
BET-31: Leaderboard general improvements

### DIFF
--- a/app/routes/dashboard/components/PropMatrix.tsx
+++ b/app/routes/dashboard/components/PropMatrix.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { IoTrophy, IoMedal, IoRibbon, IoCheckmarkCircle, IoCloseCircle, IoHelpCircle } from "react-icons/io5";
+import { IoTrophy, IoMedal, IoRibbon } from "react-icons/io5";
 import Ordinal from "~/components/Ordinal";
 
 function PropCell({ option, isWinning }: any) {
@@ -7,29 +7,22 @@ function PropCell({ option, isWinning }: any) {
   const isCorrect = option.answerId === option.id;
 
   let cellClass = "p-0.5 text-center text-[9px] font-medium transition-colors ";
-  let icon = null;
 
   if (isAnswered) {
     if (isCorrect) {
       cellClass += isWinning
         ? "bg-success text-success-content shadow-inner"
         : "bg-success/70 text-success-content";
-      icon = <IoCheckmarkCircle className="inline mr-0.5" size={10} />;
     } else {
       cellClass += "bg-error/60 text-error-content";
-      icon = <IoCloseCircle className="inline mr-0.5 opacity-50" size={8} />;
     }
   } else {
     cellClass += "bg-base-100/50";
-    icon = <IoHelpCircle className="inline mr-0.5 opacity-30" size={8} />;
   }
 
   return (
     <td className={cellClass}>
-      <div className="flex items-center justify-center gap-0.5">
-        {icon}
-        <span className="truncate max-w-[45px]">{option.shortTitle}</span>
-      </div>
+      <span className="truncate block">{option.shortTitle}</span>
     </td>
   );
 }
@@ -249,20 +242,17 @@ export default function PropMatrix({
         <div className="card-body py-4">
           <div className="flex items-center justify-center gap-8 text-xs">
             <div className="flex items-center gap-2">
-              <div className="badge badge-success gap-1">
-                <IoCheckmarkCircle size={14} />
+              <div className="badge badge-success">
                 Correct
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <div className="badge badge-error badge-outline gap-1">
-                <IoCloseCircle size={14} />
+              <div className="badge badge-error">
                 Incorrect
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <div className="badge badge-ghost gap-1">
-                <IoHelpCircle size={14} />
+              <div className="badge badge-ghost">
                 Not Yet Answered
               </div>
             </div>

--- a/app/routes/dashboard/components/PropMatrix.tsx
+++ b/app/routes/dashboard/components/PropMatrix.tsx
@@ -6,7 +6,7 @@ function PropCell({ option, isWinning }: any) {
   const isAnswered = !!option.answerId;
   const isCorrect = option.answerId === option.id;
 
-  let cellClass = "p-2 text-center text-xs font-medium transition-colors ";
+  let cellClass = "p-1 text-center text-[10px] font-medium transition-colors ";
   let icon = null;
 
   if (isAnswered) {
@@ -14,21 +14,21 @@ function PropCell({ option, isWinning }: any) {
       cellClass += isWinning
         ? "bg-success text-success-content shadow-inner"
         : "bg-success/70 text-success-content";
-      icon = <IoCheckmarkCircle className="inline mr-1" size={14} />;
+      icon = <IoCheckmarkCircle className="inline mr-0.5" size={12} />;
     } else {
       cellClass += "bg-error/60 text-error-content";
-      icon = <IoCloseCircle className="inline mr-1 opacity-50" size={12} />;
+      icon = <IoCloseCircle className="inline mr-0.5 opacity-50" size={10} />;
     }
   } else {
     cellClass += "bg-base-100/50";
-    icon = <IoHelpCircle className="inline mr-1 opacity-30" size={12} />;
+    icon = <IoHelpCircle className="inline mr-0.5 opacity-30" size={10} />;
   }
 
   return (
     <td className={cellClass}>
-      <div className="flex items-center justify-center gap-1">
+      <div className="flex items-center justify-center gap-0.5">
         {icon}
-        <span className="truncate max-w-[80px]">{option.shortTitle}</span>
+        <span className="truncate max-w-[70px]">{option.shortTitle}</span>
       </div>
     </td>
   );
@@ -37,28 +37,28 @@ function PropCell({ option, isWinning }: any) {
 function RankBadge({ ranking }: { ranking: number }) {
   if (ranking === 1) {
     return (
-      <div className="badge badge-warning badge-lg gap-1 font-bold shadow-lg">
-        <IoTrophy size={18} />
+      <div className="badge badge-warning badge-sm gap-0.5 font-bold shadow-md">
+        <IoTrophy size={14} />
         1st
       </div>
     );
   } else if (ranking === 2) {
     return (
-      <div className="badge badge-info badge-lg gap-1 font-semibold shadow-md">
-        <IoMedal size={18} />
+      <div className="badge badge-info badge-sm gap-0.5 font-semibold shadow-sm">
+        <IoMedal size={14} />
         2nd
       </div>
     );
   } else if (ranking === 3) {
     return (
-      <div className="badge badge-accent badge-lg gap-1 font-semibold shadow-md">
-        <IoRibbon size={18} />
+      <div className="badge badge-accent badge-sm gap-0.5 font-semibold shadow-sm">
+        <IoRibbon size={14} />
         3rd
       </div>
     );
   } else {
     return (
-      <div className="badge badge-ghost badge-lg font-medium">
+      <div className="badge badge-ghost badge-sm font-medium">
         <Ordinal number={ranking} />
       </div>
     );
@@ -72,8 +72,8 @@ export default function PropMatrix({
   sheet: any;
   leaders: any;
 }) {
-  const options = sheet.propositions.reduce((acc, proposition) => {
-    proposition.options.forEach((option) => {
+  const options = sheet.propositions.reduce((acc: any, proposition: any) => {
+    proposition.options.forEach((option: any) => {
       acc[option.id] = {
         ...option,
         propositionId: proposition.id,
@@ -81,11 +81,11 @@ export default function PropMatrix({
       };
     });
     return acc;
-  }, {});
+  }, {} as Record<string, any>);
 
   const stats = useMemo(() => {
     const totalProps = sheet.propositions.length;
-    const answeredProps = sheet.propositions.filter(p => p.answerId).length;
+    const answeredProps = sheet.propositions.filter((p: any) => p.answerId).length;
     const totalParticipants = leaders.length;
     const progress = totalProps > 0 ? (answeredProps / totalProps) * 100 : 0;
     const topScore = leaders.length > 0 ? leaders[0].correct : 0;
@@ -100,7 +100,7 @@ export default function PropMatrix({
   }, [sheet, leaders]);
 
   const topRanking = leaders.length > 0 ? leaders[0].ranking : 0;
-  const topLeaders = leaders.filter(l => l.ranking === topRanking);
+  const topLeaders = leaders.filter((l: any) => l.ranking === topRanking);
 
   return (
     <div className="space-y-6">
@@ -150,26 +150,26 @@ export default function PropMatrix({
       </div>
 
       {/* Leaderboard Matrix */}
-      <div className="card bg-base-100 shadow-2xl overflow-x-auto">
-        <div className="card-body p-0">
-          <table className="table table-sm table-pin-rows table-pin-cols">
+      <div className="card bg-base-100 shadow-2xl overflow-hidden">
+        <div className="card-body p-0 max-h-[calc(100vh-300px)] overflow-auto">
+          <table className="table table-xs table-pin-rows table-pin-cols">
             <thead>
               <tr className="bg-base-300">
-                <th className="bg-base-300 z-20 text-center min-w-[140px]">
-                  <div className="text-sm font-bold">Sailor</div>
+                <th className="bg-base-300 z-20 text-center min-w-[120px] sticky left-0">
+                  <div className="text-xs font-bold">Sailor</div>
                 </th>
-                <th className="bg-base-300 z-20 text-center min-w-[100px]">
-                  <div className="text-sm font-bold">Rank</div>
+                <th className="bg-base-300 z-20 text-center min-w-[80px] sticky left-[120px]">
+                  <div className="text-xs font-bold">Rank</div>
                 </th>
-                {sheet.propositions.map((proposition, index) => (
+                {sheet.propositions.map((proposition: any, index: number) => (
                   <th
                     key={index}
-                    className="bg-base-300 text-xs p-2 min-w-[120px]"
+                    className="bg-base-300 text-xs p-1 min-w-[100px]"
                     title={proposition.title}
                   >
-                    <div className="flex items-center justify-center h-32">
+                    <div className="flex items-center justify-center h-24">
                       <div
-                        className="font-medium text-center"
+                        className="font-medium text-center text-[10px]"
                         style={{
                           transform: "rotate(-55deg)",
                           whiteSpace: "nowrap",
@@ -181,13 +181,13 @@ export default function PropMatrix({
                     </div>
                   </th>
                 ))}
-                <th className="bg-base-300 text-center min-w-[80px]">
-                  <div className="text-sm font-bold">Score</div>
+                <th className="bg-base-300 text-center min-w-[70px] sticky right-0">
+                  <div className="text-xs font-bold">Score</div>
                 </th>
               </tr>
             </thead>
             <tbody>
-              {leaders.map((leader, rIndex) => {
+              {leaders.map((leader: any, rIndex: number) => {
                 const isTopThree = leader.ranking <= 3;
                 const rowClass = isTopThree
                   ? "bg-base-200/50 hover:bg-base-200"
@@ -195,32 +195,44 @@ export default function PropMatrix({
 
                 return (
                   <tr key={rIndex} className={rowClass}>
-                    <td className="font-semibold bg-base-200/80 z-10">
-                      <div className="flex items-center gap-2 px-2">
+                    <td className="font-semibold bg-base-200/80 z-10 sticky left-0">
+                      <div className="flex items-center gap-1 px-2">
                         {leader.ranking === 1 && (
-                          <IoTrophy className="text-warning" size={20} />
+                          <IoTrophy className="text-warning" size={16} />
                         )}
                         {leader.ranking === 2 && (
-                          <IoMedal className="text-info" size={20} />
+                          <IoMedal className="text-info" size={16} />
                         )}
                         {leader.ranking === 3 && (
-                          <IoRibbon className="text-accent" size={20} />
+                          <IoRibbon className="text-accent" size={16} />
                         )}
-                        <span className="text-sm">{leader.username}</span>
+                        <span className="text-xs">{leader.username}</span>
                       </div>
                     </td>
-                    <td className="text-center bg-base-200/80 z-10">
+                    <td className="text-center bg-base-200/80 z-10 sticky left-[120px]">
                       <RankBadge ranking={leader.ranking} />
                     </td>
-                    {leader.selections.map((selection, aIndex) => (
-                      <PropCell
-                        key={aIndex}
-                        option={options[selection.optionId]}
-                        isWinning={leader.ranking === 1}
-                      />
-                    ))}
-                    <td className="text-center font-bold bg-base-200/80">
-                      <div className="badge badge-lg badge-primary font-bold">
+                    {sheet.propositions.map((proposition: any, aIndex: number) => {
+                      // Find the selection for this proposition
+                      const selection = leader.selections.find((sel: any) =>
+                        options[sel.optionId]?.propositionId === proposition.id
+                      );
+                      const option = selection ? options[selection.optionId] : null;
+
+                      return option ? (
+                        <PropCell
+                          key={aIndex}
+                          option={option}
+                          isWinning={leader.ranking === 1}
+                        />
+                      ) : (
+                        <td key={aIndex} className="p-1 text-center bg-base-100/50">
+                          <span className="text-[10px] opacity-30">—</span>
+                        </td>
+                      );
+                    })}
+                    <td className="text-center font-bold bg-base-200/80 sticky right-0">
+                      <div className="badge badge-sm badge-primary font-bold">
                         {leader.correct}
                       </div>
                     </td>

--- a/app/routes/dashboard/components/PropMatrix.tsx
+++ b/app/routes/dashboard/components/PropMatrix.tsx
@@ -6,7 +6,7 @@ function PropCell({ option, isWinning }: any) {
   const isAnswered = !!option.answerId;
   const isCorrect = option.answerId === option.id;
 
-  let cellClass = "p-1 text-center text-[10px] font-medium transition-colors ";
+  let cellClass = "p-0.5 text-center text-[9px] font-medium transition-colors ";
   let icon = null;
 
   if (isAnswered) {
@@ -14,21 +14,21 @@ function PropCell({ option, isWinning }: any) {
       cellClass += isWinning
         ? "bg-success text-success-content shadow-inner"
         : "bg-success/70 text-success-content";
-      icon = <IoCheckmarkCircle className="inline mr-0.5" size={12} />;
+      icon = <IoCheckmarkCircle className="inline mr-0.5" size={10} />;
     } else {
       cellClass += "bg-error/60 text-error-content";
-      icon = <IoCloseCircle className="inline mr-0.5 opacity-50" size={10} />;
+      icon = <IoCloseCircle className="inline mr-0.5 opacity-50" size={8} />;
     }
   } else {
     cellClass += "bg-base-100/50";
-    icon = <IoHelpCircle className="inline mr-0.5 opacity-30" size={10} />;
+    icon = <IoHelpCircle className="inline mr-0.5 opacity-30" size={8} />;
   }
 
   return (
     <td className={cellClass}>
       <div className="flex items-center justify-center gap-0.5">
         {icon}
-        <span className="truncate max-w-[70px]">{option.shortTitle}</span>
+        <span className="truncate max-w-[45px]">{option.shortTitle}</span>
       </div>
     </td>
   );
@@ -37,28 +37,28 @@ function PropCell({ option, isWinning }: any) {
 function RankBadge({ ranking }: { ranking: number }) {
   if (ranking === 1) {
     return (
-      <div className="badge badge-warning badge-sm gap-0.5 font-bold shadow-md">
-        <IoTrophy size={14} />
+      <div className="badge badge-warning badge-xs gap-0.5 font-bold shadow-md">
+        <IoTrophy size={10} />
         1st
       </div>
     );
   } else if (ranking === 2) {
     return (
-      <div className="badge badge-info badge-sm gap-0.5 font-semibold shadow-sm">
-        <IoMedal size={14} />
+      <div className="badge badge-info badge-xs gap-0.5 font-semibold shadow-sm">
+        <IoMedal size={10} />
         2nd
       </div>
     );
   } else if (ranking === 3) {
     return (
-      <div className="badge badge-accent badge-sm gap-0.5 font-semibold shadow-sm">
-        <IoRibbon size={14} />
+      <div className="badge badge-accent badge-xs gap-0.5 font-semibold shadow-sm">
+        <IoRibbon size={10} />
         3rd
       </div>
     );
   } else {
     return (
-      <div className="badge badge-ghost badge-sm font-medium">
+      <div className="badge badge-ghost badge-xs font-medium text-[9px]">
         <Ordinal number={ranking} />
       </div>
     );
@@ -155,21 +155,21 @@ export default function PropMatrix({
           <table className="table table-xs table-pin-rows table-pin-cols">
             <thead>
               <tr className="bg-base-300">
-                <th className="bg-base-300 z-20 text-center min-w-[120px] sticky left-0">
+                <th className="bg-base-300 z-20 text-center w-[90px] sticky left-0">
                   <div className="text-xs font-bold">Sailor</div>
                 </th>
-                <th className="bg-base-300 z-20 text-center min-w-[80px] sticky left-[120px]">
+                <th className="bg-base-300 z-20 text-center w-[60px] sticky left-[90px]">
                   <div className="text-xs font-bold">Rank</div>
                 </th>
                 {sheet.propositions.map((proposition: any, index: number) => (
                   <th
                     key={index}
-                    className="bg-base-300 text-xs p-1 min-w-[100px]"
+                    className="bg-base-300 text-xs p-0.5 w-[55px]"
                     title={proposition.title}
                   >
-                    <div className="flex items-center justify-center h-24">
+                    <div className="flex items-center justify-center h-20">
                       <div
-                        className="font-medium text-center text-[10px]"
+                        className="font-medium text-center text-[9px]"
                         style={{
                           transform: "rotate(-55deg)",
                           whiteSpace: "nowrap",
@@ -181,7 +181,7 @@ export default function PropMatrix({
                     </div>
                   </th>
                 ))}
-                <th className="bg-base-300 text-center min-w-[70px] sticky right-0">
+                <th className="bg-base-300 text-center w-[50px] sticky right-0">
                   <div className="text-xs font-bold">Score</div>
                 </th>
               </tr>
@@ -196,20 +196,20 @@ export default function PropMatrix({
                 return (
                   <tr key={rIndex} className={rowClass}>
                     <td className="font-semibold bg-base-200/80 z-10 sticky left-0">
-                      <div className="flex items-center gap-1 px-2">
+                      <div className="flex items-center gap-0.5 px-1">
                         {leader.ranking === 1 && (
-                          <IoTrophy className="text-warning" size={16} />
+                          <IoTrophy className="text-warning" size={12} />
                         )}
                         {leader.ranking === 2 && (
-                          <IoMedal className="text-info" size={16} />
+                          <IoMedal className="text-info" size={12} />
                         )}
                         {leader.ranking === 3 && (
-                          <IoRibbon className="text-accent" size={16} />
+                          <IoRibbon className="text-accent" size={12} />
                         )}
-                        <span className="text-xs">{leader.username}</span>
+                        <span className="text-[10px] truncate">{leader.username}</span>
                       </div>
                     </td>
-                    <td className="text-center bg-base-200/80 z-10 sticky left-[120px]">
+                    <td className="text-center bg-base-200/80 z-10 sticky left-[90px]">
                       <RankBadge ranking={leader.ranking} />
                     </td>
                     {sheet.propositions.map((proposition: any, aIndex: number) => {
@@ -226,13 +226,13 @@ export default function PropMatrix({
                           isWinning={leader.ranking === 1}
                         />
                       ) : (
-                        <td key={aIndex} className="p-1 text-center bg-base-100/50">
-                          <span className="text-[10px] opacity-30">—</span>
+                        <td key={aIndex} className="p-0.5 text-center bg-base-100/50">
+                          <span className="text-[9px] opacity-30">—</span>
                         </td>
                       );
                     })}
-                    <td className="text-center font-bold bg-base-200/80 sticky right-0">
-                      <div className="badge badge-sm badge-primary font-bold">
+                    <td className="text-center font-bold bg-base-200/80 sticky right-0 p-0.5">
+                      <div className="badge badge-xs badge-primary font-bold">
                         {leader.correct}
                       </div>
                     </td>

--- a/app/routes/dashboard/components/PropMatrix.tsx
+++ b/app/routes/dashboard/components/PropMatrix.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { IoTrophy, IoMedal, IoRibbon } from "react-icons/io5";
 import Ordinal from "~/components/Ordinal";
 
@@ -76,75 +75,11 @@ export default function PropMatrix({
     return acc;
   }, {} as Record<string, any>);
 
-  const stats = useMemo(() => {
-    const totalProps = sheet.propositions.length;
-    const answeredProps = sheet.propositions.filter((p: any) => p.answerId).length;
-    const totalParticipants = leaders.length;
-    const progress = totalProps > 0 ? (answeredProps / totalProps) * 100 : 0;
-    const topScore = leaders.length > 0 ? leaders[0].correct : 0;
-
-    return {
-      totalProps,
-      answeredProps,
-      totalParticipants,
-      progress,
-      topScore
-    };
-  }, [sheet, leaders]);
-
-  const topRanking = leaders.length > 0 ? leaders[0].ranking : 0;
-  const topLeaders = leaders.filter((l: any) => l.ranking === topRanking);
-
   return (
-    <div className="space-y-6">
-      {/* Header Section */}
-      <div className="card bg-base-100 shadow-2xl">
-        <div className="card-body">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-5xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-                {sheet.title}
-              </h1>
-              {sheet.subtitle && (
-                <p className="text-xl text-base-content/70 mt-2">{sheet.subtitle}</p>
-              )}
-            </div>
-
-            <div className="stats shadow-lg">
-              <div className="stat place-items-center">
-                <div className="stat-title text-xs">Participants</div>
-                <div className="stat-value text-3xl text-primary">{stats.totalParticipants}</div>
-              </div>
-
-              <div className="stat place-items-center">
-                <div className="stat-title text-xs">Progress</div>
-                <div className="stat-value text-3xl text-secondary">
-                  {stats.answeredProps}/{stats.totalProps}
-                </div>
-                <div className="stat-desc">
-                  <progress
-                    className="progress progress-secondary w-20"
-                    value={stats.progress}
-                    max="100"
-                  ></progress>
-                </div>
-              </div>
-
-              <div className="stat place-items-center">
-                <div className="stat-title text-xs">Top Score</div>
-                <div className="stat-value text-3xl text-accent">{stats.topScore}</div>
-                <div className="stat-desc">
-                  {topLeaders.length > 1 ? `${topLeaders.length} tied` : "Leading"}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
+    <div className="space-y-4">
       {/* Leaderboard Matrix */}
-      <div className="card bg-base-100 shadow-2xl overflow-hidden">
-        <div className="card-body p-0 max-h-[calc(100vh-300px)] overflow-auto">
+      <div className="card bg-base-100 shadow-xl overflow-hidden">
+        <div className="card-body p-0 max-h-[calc(100vh-200px)] overflow-auto">
           <table className="table table-xs table-pin-rows table-pin-cols">
             <thead>
               <tr className="bg-base-300">

--- a/app/routes/dashboard/components/RaceToBottom.tsx
+++ b/app/routes/dashboard/components/RaceToBottom.tsx
@@ -1,0 +1,74 @@
+import { IoSkullOutline, IoWarning } from "react-icons/io5";
+
+function AvatarImage({ profilePictureUrl, username }: { profilePictureUrl: string | null; username: string }) {
+  if (profilePictureUrl) {
+    return (
+      <img
+        src={profilePictureUrl}
+        alt={username}
+        className="w-8 h-8 rounded-full object-cover border-2 border-error shadow-md"
+      />
+    );
+  }
+
+  const initial = username.charAt(0).toUpperCase();
+  return (
+    <div className="w-8 h-8 rounded-full bg-error text-error-content flex items-center justify-center font-bold text-sm border-2 border-error shadow-md">
+      {initial}
+    </div>
+  );
+}
+
+export default function RaceToBottom({ leaders }: { leaders: any[] }) {
+  if (leaders.length === 0) return null;
+
+  // Find the worst ranking
+  const worstRanking = Math.max(...leaders.map(l => l.ranking));
+
+  // Get all sailors with the worst ranking
+  const lastPlaceSailors = leaders.filter(l => l.ranking === worstRanking);
+
+  // Only show if there are at least 2 participants
+  if (leaders.length < 2) return null;
+
+  return (
+    <div className="card bg-error/10 border-2 border-error/30 shadow-xl">
+      <div className="card-body py-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <IoSkullOutline className="text-error" size={28} />
+              <h3 className="text-lg font-bold text-error">Race to the Bottom</h3>
+            </div>
+            <div className="badge badge-error badge-lg gap-1">
+              <IoWarning size={14} />
+              Last Place
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {lastPlaceSailors.map((sailor, index) => (
+              <div key={index} className="flex items-center gap-2 bg-base-100/80 rounded-lg px-3 py-2 shadow-md">
+                <AvatarImage
+                  profilePictureUrl={sailor.profilePictureUrl}
+                  username={sailor.username}
+                />
+                <div>
+                  <div className="font-semibold text-sm">{sailor.username}</div>
+                  <div className="text-xs text-base-content/70">
+                    {sailor.correct} correct
+                  </div>
+                </div>
+              </div>
+            ))}
+            {lastPlaceSailors.length > 1 && (
+              <div className="badge badge-warning">
+                {lastPlaceSailors.length}-way tie
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/dashboard/components/RaceView.tsx
+++ b/app/routes/dashboard/components/RaceView.tsx
@@ -7,7 +7,7 @@ function AvatarImage({ profilePictureUrl, username }: { profilePictureUrl: strin
       <img
         src={profilePictureUrl}
         alt={username}
-        className="w-10 h-10 rounded-full object-cover border-2 border-base-100 shadow-lg"
+        className="w-7 h-7 rounded-full object-cover border-2 border-base-100 shadow-md"
       />
     );
   }
@@ -15,7 +15,7 @@ function AvatarImage({ profilePictureUrl, username }: { profilePictureUrl: strin
   // Fallback avatar with first letter
   const initial = username.charAt(0).toUpperCase();
   return (
-    <div className="w-10 h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-lg border-2 border-base-100 shadow-lg">
+    <div className="w-7 h-7 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-sm border-2 border-base-100 shadow-md">
       {initial}
     </div>
   );
@@ -46,7 +46,6 @@ export default function RaceView({
 
   const topRanking = leaders.length > 0 ? leaders[0].ranking : 0;
   const topLeaders = leaders.filter((l: any) => l.ranking === topRanking);
-  const maxCorrect = Math.max(...leaders.map((l: any) => l.correct), 1);
 
   return (
     <div className="space-y-6">
@@ -99,9 +98,10 @@ export default function RaceView({
       <div className="card bg-base-100 shadow-2xl">
         <div className="card-body">
           <h2 className="text-2xl font-bold mb-4">Race View</h2>
-          <div className="space-y-3">
+          <div className="space-y-1.5">
             {leaders.map((leader: any, index: number) => {
-              const barWidth = maxCorrect > 0 ? (leader.correct / maxCorrect) * 100 : 0;
+              // Calculate bar width based on total questions, not max correct
+              const barWidth = stats.totalProps > 0 ? (leader.correct / stats.totalProps) * 100 : 0;
               const isTopThree = leader.ranking <= 3;
 
               let barColor = "bg-gradient-to-r from-primary/60 to-primary/40";
@@ -115,14 +115,14 @@ export default function RaceView({
 
               return (
                 <div key={index} className="relative group">
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-2">
                     {/* Rank Badge */}
-                    <div className="w-12 text-center flex-shrink-0">
-                      {leader.ranking === 1 && <IoTrophy className="inline text-warning" size={24} />}
-                      {leader.ranking === 2 && <IoMedal className="inline text-info" size={24} />}
-                      {leader.ranking === 3 && <IoRibbon className="inline text-accent" size={24} />}
+                    <div className="w-10 text-center flex-shrink-0">
+                      {leader.ranking === 1 && <IoTrophy className="inline text-warning" size={18} />}
+                      {leader.ranking === 2 && <IoMedal className="inline text-info" size={18} />}
+                      {leader.ranking === 3 && <IoRibbon className="inline text-accent" size={18} />}
                       {leader.ranking > 3 && (
-                        <span className="text-sm font-semibold text-base-content/70">
+                        <span className="text-xs font-semibold text-base-content/70">
                           {leader.ranking}
                         </span>
                       )}
@@ -131,11 +131,11 @@ export default function RaceView({
                     {/* Bar Container */}
                     <div className="flex-1 relative">
                       {/* Background bar */}
-                      <div className="h-14 bg-base-200/50 rounded-lg overflow-hidden relative">
+                      <div className="h-9 bg-base-200/50 rounded-md overflow-hidden relative">
                         {/* Progress bar */}
                         <div
-                          className={`h-full ${barColor} transition-all duration-500 ease-out flex items-center justify-end pr-2 shadow-lg`}
-                          style={{ width: `${Math.max(barWidth, 10)}%` }}
+                          className={`h-full ${barColor} transition-all duration-500 ease-out flex items-center justify-end pr-1.5 shadow-md`}
+                          style={{ width: `${Math.max(barWidth, 8)}%` }}
                         >
                           {/* Avatar at the tip */}
                           <div className="transform group-hover:scale-110 transition-transform">
@@ -147,13 +147,13 @@ export default function RaceView({
                         </div>
 
                         {/* Name and score overlay */}
-                        <div className="absolute inset-0 flex items-center justify-between px-4 pointer-events-none">
-                          <span className="font-semibold text-base-content drop-shadow-md">
+                        <div className="absolute inset-0 flex items-center justify-between px-3 pointer-events-none">
+                          <span className="font-semibold text-sm text-base-content drop-shadow-md">
                             {leader.username}
                           </span>
-                          <span className="font-bold text-lg">
-                            <span className="badge badge-lg badge-primary font-bold">
-                              {leader.correct}
+                          <span className="font-bold text-sm">
+                            <span className="badge badge-sm badge-primary font-bold">
+                              {leader.correct}/{stats.totalProps}
                             </span>
                           </span>
                         </div>

--- a/app/routes/dashboard/components/RaceView.tsx
+++ b/app/routes/dashboard/components/RaceView.tsx
@@ -117,10 +117,10 @@ export default function RaceView({
                 <div key={index} className="relative group">
                   <div className="flex items-center gap-2">
                     {/* Rank Badge */}
-                    <div className="w-10 text-center flex-shrink-0">
-                      {leader.ranking === 1 && <IoTrophy className="inline text-warning" size={18} />}
-                      {leader.ranking === 2 && <IoMedal className="inline text-info" size={18} />}
-                      {leader.ranking === 3 && <IoRibbon className="inline text-accent" size={18} />}
+                    <div className="w-8 text-center flex-shrink-0">
+                      {leader.ranking === 1 && <IoTrophy className="inline text-warning" size={16} />}
+                      {leader.ranking === 2 && <IoMedal className="inline text-info" size={16} />}
+                      {leader.ranking === 3 && <IoRibbon className="inline text-accent" size={16} />}
                       {leader.ranking > 3 && (
                         <span className="text-xs font-semibold text-base-content/70">
                           {leader.ranking}
@@ -128,33 +128,35 @@ export default function RaceView({
                       )}
                     </div>
 
+                    {/* Avatar */}
+                    <div className="flex-shrink-0">
+                      <AvatarImage
+                        profilePictureUrl={leader.profilePictureUrl}
+                        username={leader.username}
+                      />
+                    </div>
+
+                    {/* Username */}
+                    <div className="w-32 flex-shrink-0">
+                      <span className="font-semibold text-xs text-base-content truncate block">
+                        {leader.username}
+                      </span>
+                    </div>
+
                     {/* Bar Container */}
                     <div className="flex-1 relative">
                       {/* Background bar */}
-                      <div className="h-9 bg-base-200/50 rounded-md overflow-hidden relative">
+                      <div className="h-7 bg-base-200/50 rounded-md overflow-hidden relative">
                         {/* Progress bar */}
                         <div
-                          className={`h-full ${barColor} transition-all duration-500 ease-out flex items-center justify-end pr-1.5 shadow-md`}
-                          style={{ width: `${Math.max(barWidth, 8)}%` }}
-                        >
-                          {/* Avatar at the tip */}
-                          <div className="transform group-hover:scale-110 transition-transform">
-                            <AvatarImage
-                              profilePictureUrl={leader.profilePictureUrl}
-                              username={leader.username}
-                            />
-                          </div>
-                        </div>
+                          className={`h-full ${barColor} transition-all duration-500 ease-out shadow-md`}
+                          style={{ width: `${barWidth}%` }}
+                        />
 
-                        {/* Name and score overlay */}
-                        <div className="absolute inset-0 flex items-center justify-between px-3 pointer-events-none">
-                          <span className="font-semibold text-sm text-base-content drop-shadow-md">
-                            {leader.username}
-                          </span>
-                          <span className="font-bold text-sm">
-                            <span className="badge badge-sm badge-primary font-bold">
-                              {leader.correct}/{stats.totalProps}
-                            </span>
+                        {/* Score overlay */}
+                        <div className="absolute inset-0 flex items-center justify-end px-2 pointer-events-none">
+                          <span className="badge badge-xs badge-primary font-bold">
+                            {leader.correct}/{stats.totalProps}
                           </span>
                         </div>
                       </div>

--- a/app/routes/dashboard/components/RaceView.tsx
+++ b/app/routes/dashboard/components/RaceView.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from "react";
+import { IoTrophy, IoMedal, IoRibbon } from "react-icons/io5";
+
+function AvatarImage({ profilePictureUrl, username }: { profilePictureUrl: string | null; username: string }) {
+  if (profilePictureUrl) {
+    return (
+      <img
+        src={profilePictureUrl}
+        alt={username}
+        className="w-10 h-10 rounded-full object-cover border-2 border-base-100 shadow-lg"
+      />
+    );
+  }
+
+  // Fallback avatar with first letter
+  const initial = username.charAt(0).toUpperCase();
+  return (
+    <div className="w-10 h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold text-lg border-2 border-base-100 shadow-lg">
+      {initial}
+    </div>
+  );
+}
+
+export default function RaceView({
+  sheet,
+  leaders,
+}: {
+  sheet: any;
+  leaders: any;
+}) {
+  const stats = useMemo(() => {
+    const totalProps = sheet.propositions.length;
+    const answeredProps = sheet.propositions.filter((p: any) => p.answerId).length;
+    const totalParticipants = leaders.length;
+    const progress = totalProps > 0 ? (answeredProps / totalProps) * 100 : 0;
+    const topScore = leaders.length > 0 ? leaders[0].correct : 0;
+
+    return {
+      totalProps,
+      answeredProps,
+      totalParticipants,
+      progress,
+      topScore
+    };
+  }, [sheet, leaders]);
+
+  const topRanking = leaders.length > 0 ? leaders[0].ranking : 0;
+  const topLeaders = leaders.filter((l: any) => l.ranking === topRanking);
+  const maxCorrect = Math.max(...leaders.map((l: any) => l.correct), 1);
+
+  return (
+    <div className="space-y-6">
+      {/* Header Section */}
+      <div className="card bg-base-100 shadow-2xl">
+        <div className="card-body">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-5xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
+                {sheet.title}
+              </h1>
+              {sheet.subtitle && (
+                <p className="text-xl text-base-content/70 mt-2">{sheet.subtitle}</p>
+              )}
+            </div>
+
+            <div className="stats shadow-lg">
+              <div className="stat place-items-center">
+                <div className="stat-title text-xs">Participants</div>
+                <div className="stat-value text-3xl text-primary">{stats.totalParticipants}</div>
+              </div>
+
+              <div className="stat place-items-center">
+                <div className="stat-title text-xs">Progress</div>
+                <div className="stat-value text-3xl text-secondary">
+                  {stats.answeredProps}/{stats.totalProps}
+                </div>
+                <div className="stat-desc">
+                  <progress
+                    className="progress progress-secondary w-20"
+                    value={stats.progress}
+                    max="100"
+                  ></progress>
+                </div>
+              </div>
+
+              <div className="stat place-items-center">
+                <div className="stat-title text-xs">Top Score</div>
+                <div className="stat-value text-3xl text-accent">{stats.topScore}</div>
+                <div className="stat-desc">
+                  {topLeaders.length > 1 ? `${topLeaders.length} tied` : "Leading"}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Race View */}
+      <div className="card bg-base-100 shadow-2xl">
+        <div className="card-body">
+          <h2 className="text-2xl font-bold mb-4">Race View</h2>
+          <div className="space-y-3">
+            {leaders.map((leader: any, index: number) => {
+              const barWidth = maxCorrect > 0 ? (leader.correct / maxCorrect) * 100 : 0;
+              const isTopThree = leader.ranking <= 3;
+
+              let barColor = "bg-gradient-to-r from-primary/60 to-primary/40";
+              if (leader.ranking === 1) {
+                barColor = "bg-gradient-to-r from-warning to-warning/70";
+              } else if (leader.ranking === 2) {
+                barColor = "bg-gradient-to-r from-info to-info/70";
+              } else if (leader.ranking === 3) {
+                barColor = "bg-gradient-to-r from-accent to-accent/70";
+              }
+
+              return (
+                <div key={index} className="relative group">
+                  <div className="flex items-center gap-3">
+                    {/* Rank Badge */}
+                    <div className="w-12 text-center flex-shrink-0">
+                      {leader.ranking === 1 && <IoTrophy className="inline text-warning" size={24} />}
+                      {leader.ranking === 2 && <IoMedal className="inline text-info" size={24} />}
+                      {leader.ranking === 3 && <IoRibbon className="inline text-accent" size={24} />}
+                      {leader.ranking > 3 && (
+                        <span className="text-sm font-semibold text-base-content/70">
+                          {leader.ranking}
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Bar Container */}
+                    <div className="flex-1 relative">
+                      {/* Background bar */}
+                      <div className="h-14 bg-base-200/50 rounded-lg overflow-hidden relative">
+                        {/* Progress bar */}
+                        <div
+                          className={`h-full ${barColor} transition-all duration-500 ease-out flex items-center justify-end pr-2 shadow-lg`}
+                          style={{ width: `${Math.max(barWidth, 10)}%` }}
+                        >
+                          {/* Avatar at the tip */}
+                          <div className="transform group-hover:scale-110 transition-transform">
+                            <AvatarImage
+                              profilePictureUrl={leader.profilePictureUrl}
+                              username={leader.username}
+                            />
+                          </div>
+                        </div>
+
+                        {/* Name and score overlay */}
+                        <div className="absolute inset-0 flex items-center justify-between px-4 pointer-events-none">
+                          <span className="font-semibold text-base-content drop-shadow-md">
+                            {leader.username}
+                          </span>
+                          <span className="font-bold text-lg">
+                            <span className="badge badge-lg badge-primary font-bold">
+                              {leader.correct}
+                            </span>
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/routes/dashboard/components/RaceView.tsx
+++ b/app/routes/dashboard/components/RaceView.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { IoTrophy, IoMedal, IoRibbon } from "react-icons/io5";
 
 function AvatarImage({ profilePictureUrl, username }: { profilePictureUrl: string | null; username: string }) {
@@ -28,80 +27,15 @@ export default function RaceView({
   sheet: any;
   leaders: any;
 }) {
-  const stats = useMemo(() => {
-    const totalProps = sheet.propositions.length;
-    const answeredProps = sheet.propositions.filter((p: any) => p.answerId).length;
-    const totalParticipants = leaders.length;
-    const progress = totalProps > 0 ? (answeredProps / totalProps) * 100 : 0;
-    const topScore = leaders.length > 0 ? leaders[0].correct : 0;
-
-    return {
-      totalProps,
-      answeredProps,
-      totalParticipants,
-      progress,
-      topScore
-    };
-  }, [sheet, leaders]);
-
-  const topRanking = leaders.length > 0 ? leaders[0].ranking : 0;
-  const topLeaders = leaders.filter((l: any) => l.ranking === topRanking);
+  const totalProps = sheet.propositions.length;
 
   return (
-    <div className="space-y-6">
-      {/* Header Section */}
-      <div className="card bg-base-100 shadow-2xl">
-        <div className="card-body">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-5xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
-                {sheet.title}
-              </h1>
-              {sheet.subtitle && (
-                <p className="text-xl text-base-content/70 mt-2">{sheet.subtitle}</p>
-              )}
-            </div>
-
-            <div className="stats shadow-lg">
-              <div className="stat place-items-center">
-                <div className="stat-title text-xs">Participants</div>
-                <div className="stat-value text-3xl text-primary">{stats.totalParticipants}</div>
-              </div>
-
-              <div className="stat place-items-center">
-                <div className="stat-title text-xs">Progress</div>
-                <div className="stat-value text-3xl text-secondary">
-                  {stats.answeredProps}/{stats.totalProps}
-                </div>
-                <div className="stat-desc">
-                  <progress
-                    className="progress progress-secondary w-20"
-                    value={stats.progress}
-                    max="100"
-                  ></progress>
-                </div>
-              </div>
-
-              <div className="stat place-items-center">
-                <div className="stat-title text-xs">Top Score</div>
-                <div className="stat-value text-3xl text-accent">{stats.topScore}</div>
-                <div className="stat-desc">
-                  {topLeaders.length > 1 ? `${topLeaders.length} tied` : "Leading"}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Race View */}
-      <div className="card bg-base-100 shadow-2xl">
-        <div className="card-body">
-          <h2 className="text-2xl font-bold mb-4">Race View</h2>
-          <div className="space-y-1.5">
-            {leaders.map((leader: any, index: number) => {
-              // Calculate bar width based on total questions, not max correct
-              const barWidth = stats.totalProps > 0 ? (leader.correct / stats.totalProps) * 100 : 0;
+    <div className="card bg-base-100 shadow-xl">
+      <div className="card-body p-4">
+        <div className="space-y-1.5">
+          {leaders.map((leader: any, index: number) => {
+            // Calculate bar width based on total questions, not max correct
+            const barWidth = totalProps > 0 ? (leader.correct / totalProps) * 100 : 0;
               const isTopThree = leader.ranking <= 3;
 
               let barColor = "bg-gradient-to-r from-primary/60 to-primary/40";
@@ -156,7 +90,7 @@ export default function RaceView({
                         {/* Score overlay */}
                         <div className="absolute inset-0 flex items-center justify-end px-2 pointer-events-none">
                           <span className="badge badge-xs badge-primary font-bold">
-                            {leader.correct}/{stats.totalProps}
+                            {leader.correct}/{totalProps}
                           </span>
                         </div>
                       </div>
@@ -164,8 +98,7 @@ export default function RaceView({
                   </div>
                 </div>
               );
-            })}
-          </div>
+          })}
         </div>
       </div>
     </div>

--- a/app/routes/dashboard/route.tsx
+++ b/app/routes/dashboard/route.tsx
@@ -9,7 +9,6 @@ import {
 } from "~/models/sheet.server";
 import PropMatrix from "./components/PropMatrix";
 import RaceView from "./components/RaceView";
-import RaceToBottom from "./components/RaceToBottom";
 import { IoGrid, IoBarChart } from "react-icons/io5";
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
@@ -49,9 +48,6 @@ export default function Dashboard() {
             </button>
           </div>
         </div>
-
-        {/* Race to Bottom Widget - show in both views */}
-        <RaceToBottom leaders={leaders} />
 
         {/* Conditional View Rendering */}
         {viewMode === "race" ? (

--- a/app/routes/dashboard/route.tsx
+++ b/app/routes/dashboard/route.tsx
@@ -1,5 +1,6 @@
 import { json, LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
+import { useState } from "react";
 import invariant from "tiny-invariant";
 import {
   readLatestSheet,
@@ -7,6 +8,9 @@ import {
   readSheetDashboard,
 } from "~/models/sheet.server";
 import PropMatrix from "./components/PropMatrix";
+import RaceView from "./components/RaceView";
+import RaceToBottom from "./components/RaceToBottom";
+import { IoGrid, IoBarChart } from "react-icons/io5";
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   const latestSheet = await readLatestSheet();
@@ -21,10 +25,41 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 
 export default function Dashboard() {
   const { sheet, leaders } = useLoaderData<typeof loader>();
+  const [viewMode, setViewMode] = useState<"grid" | "race">("race");
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-base-300 via-base-200 to-base-300 p-6">
-      <PropMatrix sheet={sheet} leaders={leaders} />
+      <div className="space-y-6">
+        {/* View Toggle */}
+        <div className="flex justify-center">
+          <div className="btn-group shadow-lg">
+            <button
+              className={`btn ${viewMode === "race" ? "btn-primary" : "btn-ghost"}`}
+              onClick={() => setViewMode("race")}
+            >
+              <IoBarChart size={20} />
+              Race View
+            </button>
+            <button
+              className={`btn ${viewMode === "grid" ? "btn-primary" : "btn-ghost"}`}
+              onClick={() => setViewMode("grid")}
+            >
+              <IoGrid size={20} />
+              Grid View
+            </button>
+          </div>
+        </div>
+
+        {/* Race to Bottom Widget - show in both views */}
+        <RaceToBottom leaders={leaders} />
+
+        {/* Conditional View Rendering */}
+        {viewMode === "race" ? (
+          <RaceView sheet={sheet} leaders={leaders} />
+        ) : (
+          <PropMatrix sheet={sheet} leaders={leaders} />
+        )}
+      </div>
     </div>
   );
 }

--- a/app/routes/dashboard/route.tsx
+++ b/app/routes/dashboard/route.tsx
@@ -26,26 +26,58 @@ export default function Dashboard() {
   const { sheet, leaders } = useLoaderData<typeof loader>();
   const [viewMode, setViewMode] = useState<"grid" | "race">("race");
 
+  const totalProps = sheet.propositions.length;
+  const answeredProps = sheet.propositions.filter((p: any) => p.answerId).length;
+  const progress = totalProps > 0 ? (answeredProps / totalProps) * 100 : 0;
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-base-300 via-base-200 to-base-300 p-6">
-      <div className="space-y-6">
-        {/* View Toggle */}
-        <div className="flex justify-center">
-          <div className="btn-group shadow-lg">
-            <button
-              className={`btn ${viewMode === "race" ? "btn-primary" : "btn-ghost"}`}
-              onClick={() => setViewMode("race")}
-            >
-              <IoBarChart size={20} />
-              Race View
-            </button>
-            <button
-              className={`btn ${viewMode === "grid" ? "btn-primary" : "btn-ghost"}`}
-              onClick={() => setViewMode("grid")}
-            >
-              <IoGrid size={20} />
-              Grid View
-            </button>
+    <div className="min-h-screen bg-gradient-to-br from-base-300 via-base-200 to-base-300 p-4">
+      <div className="space-y-4">
+        {/* Compact Header with View Toggle */}
+        <div className="card bg-base-100 shadow-xl">
+          <div className="card-body p-4">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex-1">
+                <h1 className="text-2xl font-bold bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
+                  {sheet.title}
+                </h1>
+                {sheet.subtitle && (
+                  <p className="text-sm text-base-content/70 mt-1">{sheet.subtitle}</p>
+                )}
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div className="stats stats-horizontal shadow text-xs">
+                  <div className="stat py-2 px-3">
+                    <div className="stat-title text-[10px]">Players</div>
+                    <div className="stat-value text-lg text-primary">{leaders.length}</div>
+                  </div>
+                  <div className="stat py-2 px-3">
+                    <div className="stat-title text-[10px]">Progress</div>
+                    <div className="stat-value text-lg text-secondary">
+                      {answeredProps}/{totalProps}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="btn-group shadow-lg">
+                  <button
+                    className={`btn btn-sm ${viewMode === "race" ? "btn-primary" : "btn-ghost"}`}
+                    onClick={() => setViewMode("race")}
+                  >
+                    <IoBarChart size={16} />
+                    Race
+                  </button>
+                  <button
+                    className={`btn btn-sm ${viewMode === "grid" ? "btn-primary" : "btn-ghost"}`}
+                    onClick={() => setViewMode("grid")}
+                  >
+                    <IoGrid size={16} />
+                    Grid
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -75,8 +75,8 @@ const defaultSheet = {
         order: 1,
         options: {
           create: [
-            { title: "Heads", order: 1 },
-            { title: "Tails", order: 2 },
+            { title: "Heads", shortTitle: "H", order: 1 },
+            { title: "Tails", shortTitle: "T", order: 2 },
           ],
         },
       },
@@ -86,8 +86,8 @@ const defaultSheet = {
         order: 2,
         options: {
           create: [
-            { title: "Home", order: 1 },
-            { title: "Away", order: 2 },
+            { title: "Home", shortTitle: "Home", order: 1 },
+            { title: "Away", shortTitle: "Away", order: 2 },
           ],
         },
       },
@@ -97,9 +97,9 @@ const defaultSheet = {
         order: 3,
         options: {
           create: [
-            { title: "Home", order: 1 },
-            { title: "Away", order: 2 },
-            { title: "Tie", order: 3 },
+            { title: "Home", shortTitle: "Home", order: 1 },
+            { title: "Away", shortTitle: "Away", order: 2 },
+            { title: "Tie", shortTitle: "Tie", order: 3 },
           ],
         },
       },
@@ -109,8 +109,251 @@ const defaultSheet = {
         order: 4,
         options: {
           create: [
-            { title: "Yes", order: 1 },
-            { title: "No", order: 2 },
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Total touchdowns in the game",
+        shortTitle: "Total TDs",
+        order: 5,
+        options: {
+          create: [
+            { title: "Over 6.5", shortTitle: "Over", order: 1 },
+            { title: "Under 6.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will there be a safety?",
+        shortTitle: "Safety",
+        order: 6,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "First score type",
+        shortTitle: "1st score",
+        order: 7,
+        options: {
+          create: [
+            { title: "Touchdown", shortTitle: "TD", order: 1 },
+            { title: "Field Goal", shortTitle: "FG", order: 2 },
+            { title: "Safety", shortTitle: "Saf", order: 3 },
+          ],
+        },
+      },
+      {
+        title: "Winning team total points",
+        shortTitle: "Winner pts",
+        order: 8,
+        options: {
+          create: [
+            { title: "Over 27.5", shortTitle: "Over", order: 1 },
+            { title: "Under 27.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Longest touchdown",
+        shortTitle: "Long TD",
+        order: 9,
+        options: {
+          create: [
+            { title: "Over 45.5 yards", shortTitle: "Over", order: 1 },
+            { title: "Under 45.5 yards", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will there be a missed field goal?",
+        shortTitle: "Missed FG",
+        order: 10,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Total field goals made",
+        shortTitle: "FGs made",
+        order: 11,
+        options: {
+          create: [
+            { title: "Over 3.5", shortTitle: "Over", order: 1 },
+            { title: "Under 3.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will there be a punt return touchdown?",
+        shortTitle: "Punt ret TD",
+        order: 12,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will there be a kickoff return touchdown?",
+        shortTitle: "KO ret TD",
+        order: 13,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Total turnovers in the game",
+        shortTitle: "Turnovers",
+        order: 14,
+        options: {
+          create: [
+            { title: "Over 2.5", shortTitle: "Over", order: 1 },
+            { title: "Under 2.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will there be a defensive touchdown?",
+        shortTitle: "Def TD",
+        order: 15,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Largest lead in the game",
+        shortTitle: "Max lead",
+        order: 16,
+        options: {
+          create: [
+            { title: "Over 13.5 points", shortTitle: "Over", order: 1 },
+            { title: "Under 13.5 points", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Fourth quarter total points",
+        shortTitle: "4th Q pts",
+        order: 17,
+        options: {
+          create: [
+            { title: "Over 13.5", shortTitle: "Over", order: 1 },
+            { title: "Under 13.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will there be a successful two-point conversion?",
+        shortTitle: "2pt conv",
+        order: 18,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Total sacks in the game",
+        shortTitle: "Sacks",
+        order: 19,
+        options: {
+          create: [
+            { title: "Over 5.5", shortTitle: "Over", order: 1 },
+            { title: "Under 5.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will the game be decided by 3 points or fewer?",
+        shortTitle: "Close game",
+        order: 20,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Total passing touchdowns",
+        shortTitle: "Pass TDs",
+        order: 21,
+        options: {
+          create: [
+            { title: "Over 3.5", shortTitle: "Over", order: 1 },
+            { title: "Under 3.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Total rushing touchdowns",
+        shortTitle: "Rush TDs",
+        order: 22,
+        options: {
+          create: [
+            { title: "Over 1.5", shortTitle: "Over", order: 1 },
+            { title: "Under 1.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Longest field goal made",
+        shortTitle: "Long FG",
+        order: 23,
+        options: {
+          create: [
+            { title: "Over 47.5 yards", shortTitle: "Over", order: 1 },
+            { title: "Under 47.5 yards", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will there be a successful challenge?",
+        shortTitle: "Challenge",
+        order: 24,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Total penalties called",
+        shortTitle: "Penalties",
+        order: 25,
+        options: {
+          create: [
+            { title: "Over 10.5", shortTitle: "Over", order: 1 },
+            { title: "Under 10.5", shortTitle: "Under", order: 2 },
+          ],
+        },
+      },
+      {
+        title: "Will the winning team score in all four quarters?",
+        shortTitle: "Score 4Qs",
+        order: 26,
+        options: {
+          create: [
+            { title: "Yes", shortTitle: "Yes", order: 1 },
+            { title: "No", shortTitle: "No", order: 2 },
           ],
         },
       },


### PR DESCRIPTION
## Summary
- Fixed alignment bug where answers don't line up with columns in grid view
- Added two toggleable views: Race View (horizontal bar graph) and Grid View (optimized matrix)
- Optimized both views for maximum screen real estate
- Consolidated header with integrated view toggle controls

## Changes
### Grid View
- Fixed column alignment bug by iterating over propositions instead of selections
- Narrowed all columns while retaining titles (55px for props)
- Removed icons from cells, kept color coding (green=correct, red=incorrect, gray=unanswered)
- Optimized sticky columns and reduced padding

### Race View
- Implemented horizontal bar graph visualization
- Thin bars (h-7) to show more entries on screen
- Bar width based on total questions (shows remaining progress)
- Layout: Rank icon → Avatar → Username → Progress bar with score overlay
- Color-coded bars for top 3 positions (gold, silver, bronze)

### Dashboard Layout
- Created unified compact header with title, stats, and view toggle
- Reduced padding from p-6 to p-4 for tighter layout
- Smaller button and stat sizes (btn-sm, stats text-xs)
- Removed duplicate headers from child components
- Saves significant vertical screen space

### Seed Script
- Expanded from 4 to 26 Super Bowl propositions
- All propositions and options have shortTitle fields
- Supports realistic leaderboard testing

## Test plan
- [x] Verify grid view alignment matches propositions correctly
- [x] Toggle between Race and Grid views
- [x] Check responsive layout on different screen sizes
- [x] Verify color coding in grid cells
- [x] Test with 26 questions using seed script
- [x] Confirm header consolidation saves screen space

🤖 Generated with [Claude Code](https://claude.com/claude-code)