### PR TITLE
feat: Add searchbar component to dashboard

### DIFF
--- a/app/routes/dashboard/components/SearchBar.tsx
+++ b/app/routes/dashboard/components/SearchBar.tsx
@@ -1,0 +1,43 @@
+import { IoSearch, IoClose } from "react-icons/io5";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export default function SearchBar({
+  value,
+  onChange,
+  placeholder = "Search sailors...",
+  className = "",
+}: SearchBarProps) {
+  return (
+    <div className={`relative ${className}`}>
+      <div className="relative flex items-center">
+        <IoSearch
+          size={16}
+          className="absolute left-3 text-base-content/60 pointer-events-none"
+        />
+        <input
+          type="text"
+          placeholder={placeholder}
+          className="input input-sm input-bordered w-full pl-9 pr-8 bg-base-100"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        {value && (
+          <button
+            type="button"
+            className="absolute right-1 btn btn-xs btn-ghost btn-circle"
+            onClick={() => onChange("")}
+            aria-label="Clear search"
+          >
+            <IoClose size={14} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/routes/dashboard/route.tsx
+++ b/app/routes/dashboard/route.tsx
@@ -1,6 +1,6 @@
 import { json, LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import invariant from "tiny-invariant";
 import {
   readLatestSheet,
@@ -9,6 +9,7 @@ import {
 } from "~/models/sheet.server";
 import PropMatrix from "./components/PropMatrix";
 import RaceView from "./components/RaceView";
+import SearchBar from "./components/SearchBar";
 import { IoGrid, IoBarChart } from "react-icons/io5";
 
 export const loader = async ({ params, request }: LoaderFunctionArgs) => {
@@ -25,10 +26,25 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 export default function Dashboard() {
   const { sheet, leaders } = useLoaderData<typeof loader>();
   const [viewMode, setViewMode] = useState<"grid" | "race">("race");
+  const [searchQuery, setSearchQuery] = useState("");
 
   const totalProps = sheet.propositions.length;
   const answeredProps = sheet.propositions.filter((p: any) => p.answerId).length;
   const progress = totalProps > 0 ? (answeredProps / totalProps) * 100 : 0;
+
+  // Filter leaders based on search query
+  const filteredLeaders = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return leaders;
+    }
+
+    const query = searchQuery.toLowerCase();
+    return leaders.filter((leader: any) => {
+      const username = leader.username?.toLowerCase() || "";
+      const nickname = leader.nickname?.toLowerCase() || "";
+      return username.includes(query) || nickname.includes(query);
+    });
+  }, [leaders, searchQuery]);
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-base-300 via-base-200 to-base-300 p-4">
@@ -46,11 +62,20 @@ export default function Dashboard() {
                 )}
               </div>
 
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-3 flex-wrap">
+                <SearchBar
+                  value={searchQuery}
+                  onChange={setSearchQuery}
+                  placeholder="Search sailors..."
+                  className="w-48"
+                />
+
                 <div className="stats stats-horizontal shadow text-xs">
                   <div className="stat py-2 px-3">
                     <div className="stat-title text-[10px]">Players</div>
-                    <div className="stat-value text-lg text-primary">{leaders.length}</div>
+                    <div className="stat-value text-lg text-primary">
+                      {searchQuery ? `${filteredLeaders.length}/${leaders.length}` : leaders.length}
+                    </div>
                   </div>
                   <div className="stat py-2 px-3">
                     <div className="stat-title text-[10px]">Progress</div>
@@ -82,10 +107,24 @@ export default function Dashboard() {
         </div>
 
         {/* Conditional View Rendering */}
-        {viewMode === "race" ? (
-          <RaceView sheet={sheet} leaders={leaders} />
+        {filteredLeaders.length === 0 && searchQuery ? (
+          <div className="card bg-base-100 shadow-xl">
+            <div className="card-body p-8 text-center">
+              <p className="text-base-content/60">
+                No sailors found matching "{searchQuery}"
+              </p>
+              <button
+                className="btn btn-sm btn-ghost mx-auto"
+                onClick={() => setSearchQuery("")}
+              >
+                Clear search
+              </button>
+            </div>
+          </div>
+        ) : viewMode === "race" ? (
+          <RaceView sheet={sheet} leaders={filteredLeaders} />
         ) : (
-          <PropMatrix sheet={sheet} leaders={leaders} />
+          <PropMatrix sheet={sheet} leaders={filteredLeaders} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add a shared SearchBar component that filters leaders by username or nickname
- Searchbar works across both Race and Grid views
- Displays filtered player count when searching
- Empty state shown when no results match the search query

## Test plan
- [ ] Test search by username in both Race and Grid views
- [ ] Test search by nickname in both views
- [ ] Verify clear button works and resets the view
- [ ] Check empty state appears when no results match