### PR TITLE
Add leaderboard search and collapse prize metrics

### DIFF
--- a/app/routes/dashboard/components/SearchBar.tsx
+++ b/app/routes/dashboard/components/SearchBar.tsx
@@ -18,7 +18,7 @@ export default function SearchBar({
       <div className="relative flex items-center">
         <IoSearch
           size={16}
-          className="absolute left-3 text-base-content/60 pointer-events-none"
+          className="absolute left-3 text-primary pointer-events-none z-10"
         />
         <input
           type="text"

--- a/app/routes/sheets.$sheetId.admin/components/Submissions/index.tsx
+++ b/app/routes/sheets.$sheetId.admin/components/Submissions/index.tsx
@@ -136,7 +136,7 @@ export default function Submissions({
           {/* Preserve pageSize in search form */}
           <input type="hidden" name="pageSize" value={pageSize} />
           <div className="relative">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-accent">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-primary z-10">
               <IoSearch size={20} />
             </span>
             <input

--- a/app/routes/sheets.$sheetId.leaders/components/LeaderBoard/index.tsx
+++ b/app/routes/sheets.$sheetId.leaders/components/LeaderBoard/index.tsx
@@ -1,8 +1,10 @@
 import { Sailor, Sheet } from "@prisma/client";
 import { Link } from "@remix-run/react";
+import { useState, useMemo } from "react";
 import { IoCashOutline, IoTrophyOutline } from "react-icons/io5";
 import Ordinal from "~/components/Ordinal";
 import { SheetLeader } from "~/models/sheet.server";
+import SearchBar from "~/routes/dashboard/components/SearchBar";
 
 const calculatePrizePool = (paidCount: number) => {
   const ENTRY_FEE = 10;
@@ -34,8 +36,23 @@ export default function LeaderBoard({
   leaders: SheetLeader[];
   paidCount: number;
 }) {
+  const [searchQuery, setSearchQuery] = useState("");
   const prizePool = calculatePrizePool(paidCount);
-  const groupedLeaders = leaders.reduce((acc, leader) => {
+
+  // Filter leaders based on search query
+  const filteredLeaders = useMemo(() => {
+    if (!searchQuery.trim()) return leaders;
+
+    const query = searchQuery.toLowerCase();
+    return leaders.filter(
+      (leader) =>
+        leader.username?.toLowerCase().includes(query) ||
+        leader.nickname?.toLowerCase().includes(query)
+    );
+  }, [leaders, searchQuery]);
+
+  // Group filtered leaders by ranking
+  const groupedLeaders = filteredLeaders.reduce((acc, leader) => {
     const rankingGroup = acc.find((group) => group.ranking === leader.ranking);
     if (rankingGroup) {
       rankingGroup.leaders.push(leader);
@@ -73,123 +90,133 @@ export default function LeaderBoard({
           <p className="opacity-70">Top performers for {sheet.title}</p>
         </div>
 
-        <div className="stats stats-vertical sm:stats-horizontal shadow bg-base-100 w-full mb-6">
-          <div className="stat">
-            <div className="stat-figure text-success">
-              <IoCashOutline size={32} />
-            </div>
-            <div className="stat-title">Total Prize Pool</div>
-            <div className="stat-value text-success">
-              ${prizePool.afterRake.toFixed(0)}
-            </div>
-            <div className="stat-desc">
-              {paidCount} paid entries • 20% rake applied
-            </div>
+        <div className="collapse collapse-arrow bg-base-100 shadow mb-6">
+          <input type="checkbox" />
+          <div className="collapse-title text-sm font-medium opacity-70">
+            Prize Pool: ${prizePool.afterRake.toFixed(0)} • 1st: $
+            {prizePool.winnerPrize.toFixed(0)} • Last: $
+            {prizePool.loserPrize.toFixed(0)}
           </div>
-          <div className="stat">
-            <div className="stat-figure text-warning">
-              <IoTrophyOutline size={32} />
-            </div>
-            <div className="stat-title">1st Place Prize</div>
-            <div className="stat-value text-warning">
-              ${prizePool.winnerPrize.toFixed(0)}
-            </div>
-            <div className="stat-desc">90% of prize pool</div>
-          </div>
-          <div className="stat">
-            <div className="stat-figure text-info">
-              <IoTrophyOutline size={32} />
-            </div>
-            <div className="stat-title">Last Place Prize</div>
-            <div className="stat-value text-info">
-              ${prizePool.loserPrize.toFixed(0)}
-            </div>
-            <div className="stat-desc">10% of prize pool</div>
-          </div>
-        </div>
-
-        <div className="alert alert-info shadow-lg mb-6">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            className="stroke-current shrink-0 w-6 h-6"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-            ></path>
-          </svg>
-          <span>
-            <strong>Tip:</strong> Click on any sailor below to view their full
-            submission
-          </span>
-        </div>
-
-        <div className="space-y-6">
-          {groupedLeaders.map((group) => (
-            <div key={group.ranking} className="card bg-base-100 shadow-xl">
-              <div className="card-body">
-                <div className="flex items-center gap-3 mb-4">
-                  <div
-                    className={`text-4xl font-black ${getRankColor(
-                      group.ranking,
-                    )}`}
-                  >
-                    <Ordinal number={group.ranking} />
-                  </div>
-                  <div
-                    className={`badge badge-lg ${getRankBadge(
-                      group.ranking,
-                    )} font-bold shadow-md`}
-                  >
-                    {group.correct} Correct
-                  </div>
+          <div className="collapse-content">
+            <div className="stats stats-vertical sm:stats-horizontal w-full mt-2">
+              <div className="stat">
+                <div className="stat-figure text-success">
+                  <IoCashOutline size={24} />
                 </div>
-
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4">
-                  {group.leaders.map((leader) => (
-                    <Link
-                      key={leader.submissionId}
-                      to={`/sheets/${sheet.id}/submissions/${leader.submissionId}`}
-                      className="flex flex-col items-center gap-3 p-4 rounded-lg bg-base-200 hover:bg-primary hover:text-primary-content transition-all hover:scale-105 cursor-pointer shadow-md hover:shadow-xl border-2 border-transparent hover:border-primary"
-                      title={`View ${leader.username}'s submission`}
-                    >
-                      <div className="relative">
-                        <img
-                          src={
-                            leader.profilePictureUrl ?? "/fallback-avatar.svg"
-                          }
-                          alt={leader.username}
-                          width={64}
-                          height={64}
-                          className="sm:w-20 sm:h-20 w-16 h-16 rounded-full object-cover ring-4 ring-base-300 bg-accent"
-                        />
-                        {sailor.id === leader.sailorId && (
-                          <span className="badge badge-primary badge-xs absolute -bottom-1.5 -right-1.5">
-                            you
-                          </span>
-                        )}
-                      </div>
-                      <div className="text-center w-full">
-                        <div className="font-bold text-xs sm:text-sm">
-                          {leader.nickname || leader.username}
-                        </div>
-                        {leader.nickname && (
-                          <div className="text-xs opacity-60">
-                            @{leader.username}
-                          </div>
-                        )}
-                      </div>
-                    </Link>
-                  ))}
+                <div className="stat-title text-xs">Total Prize Pool</div>
+                <div className="stat-value text-success text-2xl">
+                  ${prizePool.afterRake.toFixed(0)}
+                </div>
+                <div className="stat-desc text-xs">
+                  {paidCount} paid entries • 20% rake applied
                 </div>
               </div>
+              <div className="stat">
+                <div className="stat-figure text-warning">
+                  <IoTrophyOutline size={24} />
+                </div>
+                <div className="stat-title text-xs">1st Place Prize</div>
+                <div className="stat-value text-warning text-2xl">
+                  ${prizePool.winnerPrize.toFixed(0)}
+                </div>
+                <div className="stat-desc text-xs">90% of prize pool</div>
+              </div>
+              <div className="stat">
+                <div className="stat-figure text-info">
+                  <IoTrophyOutline size={24} />
+                </div>
+                <div className="stat-title text-xs">Last Place Prize</div>
+                <div className="stat-value text-info text-2xl">
+                  ${prizePool.loserPrize.toFixed(0)}
+                </div>
+                <div className="stat-desc text-xs">10% of prize pool</div>
+              </div>
             </div>
-          ))}
+          </div>
         </div>
+
+        <SearchBar
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder="Search sailors by name..."
+          className="mb-6"
+        />
+
+        {groupedLeaders.length === 0 ? (
+          <div className="card bg-base-100 shadow-xl">
+            <div className="card-body text-center py-12">
+              <p className="text-lg opacity-70">
+                No sailors found matching "{searchQuery}"
+              </p>
+              <p className="text-sm opacity-50 mt-2">
+                Try a different search term
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {groupedLeaders.map((group) => (
+              <div key={group.ranking} className="card bg-base-100 shadow-xl">
+                <div className="card-body">
+                  <div className="flex items-center gap-3 mb-4">
+                    <div
+                      className={`text-4xl font-black ${getRankColor(
+                        group.ranking,
+                      )}`}
+                    >
+                      <Ordinal number={group.ranking} />
+                    </div>
+                    <div
+                      className={`badge badge-lg ${getRankBadge(
+                        group.ranking,
+                      )} font-bold shadow-md`}
+                    >
+                      {group.correct} Correct
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4">
+                    {group.leaders.map((leader) => (
+                      <Link
+                        key={leader.submissionId}
+                        to={`/sheets/${sheet.id}/submissions/${leader.submissionId}`}
+                        className="flex flex-col items-center gap-3 p-4 rounded-lg bg-base-200 hover:bg-primary hover:text-primary-content transition-all hover:scale-105 cursor-pointer shadow-md hover:shadow-xl border-2 border-transparent hover:border-primary"
+                        title={`View ${leader.username}'s submission`}
+                      >
+                        <div className="relative">
+                          <img
+                            src={
+                              leader.profilePictureUrl ?? "/fallback-avatar.svg"
+                            }
+                            alt={leader.username}
+                            width={64}
+                            height={64}
+                            className="sm:w-20 sm:h-20 w-16 h-16 rounded-full object-cover ring-4 ring-base-300 bg-accent"
+                          />
+                          {sailor.id === leader.sailorId && (
+                            <span className="badge badge-primary badge-xs absolute -bottom-1.5 -right-1.5">
+                              you
+                            </span>
+                          )}
+                        </div>
+                        <div className="text-center w-full">
+                          <div className="font-bold text-xs sm:text-sm">
+                            {leader.nickname || leader.username}
+                          </div>
+                          {leader.nickname && (
+                            <div className="text-xs opacity-60">
+                              @{leader.username}
+                            </div>
+                          )}
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add search functionality to leaderboard to filter sailors by username or nickname
- Maintain ranking groups when filtering results for better organization
- Convert prize pool section to collapsible component to de-emphasize metrics and focus on leaderboard
- Fix search icon visibility across dashboard and admin by updating to primary theme color and adding z-index layering

## Test Plan
- [x] Leaderboard search filters sailors correctly
- [x] Ranking groups are maintained during filtering
- [x] Prize metrics are hidden by default and expandable
- [x] Search icons are visible on dashboard and admin pages
- [x] Build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)